### PR TITLE
Feature/wplug 175 related articles in teaser

### DIFF
--- a/plugins/se.infomaker.ximteaser/InsertTeaserArticleCommand.js
+++ b/plugins/se.infomaker.ximteaser/InsertTeaserArticleCommand.js
@@ -1,0 +1,37 @@
+import {WriterCommand} from 'writer'
+
+class InsertTeaserArticleCommand extends WriterCommand {
+
+    /**
+     * Handles insertion of image in a teaser node. If the insert happens
+     * at the same time as a transaction, that transaction needs to be supplied to
+     * the command. If not, it can be omitted.
+     *
+     * @param params
+     * @param context
+     */
+    execute(params, context) {
+        if(params.tx) {
+            this._handleInsert(params.tx, params)
+        } else {
+            context.editorSession.transaction((tx) => this._handleInsert(tx, params))
+        }
+    }
+
+    _handleInsert(tx, params) {
+        const activeTeaserNode = params.context.node
+
+        const article = {
+            title: params.data.uriData.name,
+            uuid: params.data.uriData.uuid
+        }
+
+        if (!article.uuid) {
+            throw new Error('Unsupported data. UUID must exist')
+        }
+
+        activeTeaserNode.addRelatedArticle(article, tx)
+    }
+}
+
+export default InsertTeaserArticleCommand

--- a/plugins/se.infomaker.ximteaser/README.md
+++ b/plugins/se.infomaker.ximteaser/README.md
@@ -25,6 +25,7 @@ The plugin adds one or more objects to the metadata-section of the idf.
                     <link rel="crop" type="x-im/crop" title="1:1" uri="im://crop/0.1975/0/0.605/1"/>
                 </links>
             </link>
+            <link rel="article" type="x-im/article" title="Tintin i Hajsjön" uuid="22885008-ec24-4b59-8edf-67109322f49c"/>
         </links>
     </object>
     <object id="NjMsMTExLDIzMSwxNzE" type="x-im/facebook-teaser" title="Lorem ipsum">
@@ -44,7 +45,7 @@ The plugin adds one or more objects to the metadata-section of the idf.
 </metadata>
 ```
 
-*Note* that `object > links` is optional, i.e. if no images are present
+*Note* that `object > links` is optional, i.e. if no images or related articles are present
 this element is omitted.
 
 ## Plugin Configuration

--- a/plugins/se.infomaker.ximteaser/README.md
+++ b/plugins/se.infomaker.ximteaser/README.md
@@ -4,7 +4,7 @@ the plugin configuration (see below).
 
 Each teaser type has configurable data-type, content fields, and image options.
 
-## NewsItem Format
+## Output
 The plugin adds one or more objects to the metadata-section of the idf.
 
 ```xml
@@ -13,6 +13,7 @@ The plugin adds one or more objects to the metadata-section of the idf.
         <data>
             <text>Mauris at libero condimentum sapien malesuada efficitur non id nibh.</text>
             <subject>Lorem ipsum dolor sit amet, consectetur adipiscing elit</subject>
+            <customText>Duis aute irure dolor</customText>
         </data>
         <links>
             <link rel="image" type="x-im/image" uri="im://image/fmglga0fK54ZwKjnufQgG027eOA.png" uuid="00000000-0000-0000-0000-000000000000">
@@ -35,57 +36,115 @@ The plugin adds one or more objects to the metadata-section of the idf.
                 <element id="paragraph-360f09442467b39801c6f60971b9c02c" type="body">Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</element>
                 <element id="paragraph-337d42c0a735a1faab645382bbf39fff" type="body">Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</element>
             </text>
-        </data>
-    </object>
-    <object id="PkEs6SJgLeQ0FS1qMjk" type="x-im/twitter-teaser" title="Lorem ipsum">
-        <data>
-            <text>Mauris at libero condimentum sapien malesuada efficitur non id nibh.</text>
+            <customDateField>2017-01-30</customDateField>
         </data>
     </object>
 </metadata>
 ```
 
-*Note* that `object > links` is optional, i.e. if no images or related articles are present
-this element is omitted.
+**Notes on Output**
+ * `object > links` is optional, i.e. if no images or related articles are present this element is omitted.
+ * `object > data` may contain different elements depending on the teaser's `fields`-configuration. See [Custom Fields](#custom-fields)
 
-## Plugin Configuration
-[Basic plugin configuration example](#basic-configuration-example)
+## Plugin configuration
+For the most basic configuration, with one teaser and the standard text fields, see [Basic plugin configuration example](#basic-configuration-example).
 
-```javascript
+```json
 {
-    "id": "se.infomaker.ximteaser",
-    "name": "ximteaser",
-    "mandatory": false,
-    "enabled": true,
-    "data": {
-        "teaserPosition": "top",
+  "plugins": [
+    {
+      "id": "se.infomaker.ximteaser",
+      "name": "ximteaser",
+      "url": "https://plugins.writer.infomaker.io/releases/4.1.0/im-ximteaser.js",
+      "style": "https://plugins.writer.infomaker.io/releases/4.1.0/im-ximteaser.css",
+      "mandatory": false,
+      "enabled": true,
+      "data": {
         "disableUseOfAnnotationToolsForFields": [
-            "title"
+          "title"
         ],
+        "teaserPosition": "top",
         "types": [
-            {
-                "type": "x-im/teaser",
-                "label": "Teaser",
-                "icon": "fa-newspaper-o",
-                "imageoptions": { ... },
-                "fields": [ ... ]
-            },
-            {
-                "type": "x-im/facebook-teaser",
-                "label": "Facebook",
-                "icon": "fa-facebook",
-                "imageoptions": { ... },
-                "fields": [ ... ]
-            },
-            {
-                "type": "x-im/twitter-teaser",
-                "label": "Twitter",
-                "icon": "fa-twitter",
-                "imageoptions": { ... },
-                "fields": [ ... ]
+          {
+            "label": "Teaser",
+            "type": "x-im/teaser",
+            "fields": [
+              {
+                "icon": "fa-flag",
+                "id": "subject",
+                "label": "Subject"
+              },
+              {
+                "icon": "fa-header",
+                "id": "title",
+                "label": "Rubrik"
+              },
+              {
+                "icon": "fa-paragraph",
+                "id": "text",
+                "label": "Text"
+              },
+              {
+                "icon": "fa-paragraph",
+                "id": "customText",
+                "type": "text",
+                "label": "Custom Text"
+              }
+            ],
+            "icon": "fa-newspaper-o",
+            "imageoptions": {
+              "crops": {
+                "16:9": [16, 9],
+                "1:1": [1, 1],
+                "4:3": [4, 3],
+                "8:5": [8, 5]
+              },
+              "imageinfo": true,
+              "softcrop": true
             }
+          },
+          {
+            "type": "x-im/facebook-teaser",
+            "label": "Facebook",
+            "fields": [
+              {
+                "icon": "fa-flag",
+                "id": "subject",
+                "label": "Subject"
+              },
+              {
+                "icon": "fa-header",
+                "id": "title",
+                "label": "Rubrik"
+              },
+              {
+                "icon": "fa-paragraph",
+                "id": "text",
+                "label": "Text"
+              },              
+              {
+                "id": "customDateField",
+                "label": "Custom Date Field",
+                "icon": "fa-calendar",
+                "type": "date"
+              }
+            ],
+            "icon": "fa-facebook",
+            "imageoptions": {
+              "crops": {
+                "16:9": [16, 9],
+                "1:1": [1, 1],
+                "4:3": [4, 3],
+                "8:5": [8, 5]
+              },
+              "imageinfo": true,
+              "softcrop": true
+            }
+          }
         ]
+      }
     }
+  ]
 }
 ```
 
@@ -173,13 +232,14 @@ Field Configuration Example:
 ]
 ```
 
-| Property      | Type      | Required  | Description   |
-| --------      | :--:      | :------:  | -----------   |
-| **id**        | String    | `true`    | subject, title, or text (any other string will result in a custom field) |
-| **label**     | String    | `true`    | Placeholder for field |
-| **icon**      | String    | `false`   | Sets icon used for field. Default value is `"fa-header"` Uses [FontAwesome icons](http://fontawesome.io/icons/). e.g `"fa-twitter"`. |
+| Property       | Type      | Required  | Description   |
+| --------       | :--:      | :------:  | -----------   |
+| **id**         | String    | `true`    | subject, title, or text (any other string will result in a custom field) |
+| **label**      | String    | `true`    | Placeholder for field |
+| **icon**       | String    | `false`   | Sets icon used for field. Default value is `"fa-header"` Uses [FontAwesome icons](http://fontawesome.io/icons/). e.g `"fa-twitter"`. |
 | **multiline*** | Boolean   | `false`   | **Only available for field with id `text`** Set to `true` to enable multiline text editing. Default value is `false` |
-| **type***     | String    | `false`    |  **Only available on custom fields** Choose the type of input to use for the field. One of `"text"`, `"datetime"`, `"date"`, `"time"`. Default: `"text"`|
+| **type***      | String    | `false`   |  **Only available on custom fields** Choose the type of input to use for the field. One of `"text"`, `"datetime"`, `"date"`, `"time"`. Default: `"text"`|
+
 **\*Warning** Enabling multiline editing will change the output of `data > text`-element.
 
 ### Outout Difference Between Multiline and Simple Text

--- a/plugins/se.infomaker.ximteaser/README.md
+++ b/plugins/se.infomaker.ximteaser/README.md
@@ -92,6 +92,7 @@ For the most basic configuration, with one teaser and the standard text fields, 
               }
             ],
             "icon": "fa-newspaper-o",
+            "enableRelatedArticles": false,
             "imageoptions": {
               "crops": {
                 "16:9": [16, 9],
@@ -121,7 +122,7 @@ For the most basic configuration, with one teaser and the standard text fields, 
                 "icon": "fa-paragraph",
                 "id": "text",
                 "label": "Text"
-              },              
+              },
               {
                 "id": "customDateField",
                 "label": "Custom Date Field",
@@ -130,6 +131,7 @@ For the most basic configuration, with one teaser and the standard text fields, 
               }
             ],
             "icon": "fa-facebook",
+            "enableRelatedArticles": false,
             "imageoptions": {
               "crops": {
                 "16:9": [16, 9],
@@ -164,19 +166,21 @@ Types Configuration Example:
     "type": "x-im/teaser",
     "label": "Teaser",
     "icon": "fa-newspaper-o",
+    "enableRelatedArticles": false,
     "imageoptions": { ... },
     "fields": [ ... ]
 }
 ```
 
 
-| Property          | Type      | Required  | Description   |
-| --------          | :--:      | :------:  | -----------   |
-| **type**          | String    | `true`    | Datatype of teaser which is rendered in the XML as `<object type="[type]">`, e.g `<object type="x-im/teaser">`. |
-| **label**         | String    | `true`    | Descriptive label for Type, displayed in tab menu. |
-| **icon**          | String    | `true`    | Icon used in tab menu, uses [FontAwesome icons](http://fontawesome.io/icons/). e.g `"fa-twitter"`. |
-| **imageoptions**  | Object    | `true`    | Describes image options for type. See [Image Options Configuration](#image-options-configuration) |
-| **fields**        | Array     | `true`    | Description of enabled input fields. To disable a specific field, remove it from this array. See [Fields Options Configuration](#fields-options-configuration) |
+| Property                      | Type      | Required  | Description   |
+| --------                      | :--:      | :------:  | -----------   |
+| **type**                      | String    | `true`    | Datatype of teaser which is rendered in the XML as `<object type="[type]">`, e.g `<object type="x-im/teaser">`. |
+| **label**                     | String    | `true`    | Descriptive label for Type, displayed in tab menu. |
+| **icon**                      | String    | `true`    | Icon used in tab menu, uses [FontAwesome icons](http://fontawesome.io/icons/). e.g `"fa-twitter"`. |
+| **enableRelatedArticles**     | Boolean   | `false`   | Set to `true` to enable adding related articles to teaser. Defaults to `false`. |
+| **imageoptions**              | Object    | `true`    | Describes image options for type. See [Image Options Configuration](#image-options-configuration) |
+| **fields**                    | Array     | `true`    | Description of enabled input fields. To disable a specific field, remove it from this array. See [Fields Options Configuration](#fields-options-configuration) |
 
 ### Image Options Configuration
 Image Options Configuration Example:

--- a/plugins/se.infomaker.ximteaser/RelatedArticlesComponent.js
+++ b/plugins/se.infomaker.ximteaser/RelatedArticlesComponent.js
@@ -1,0 +1,41 @@
+import { Component } from 'substance'
+
+class RelatedArticlesComponent extends Component {
+    constructor(...args) {
+        super(...args)
+    }
+
+    render($$) {
+        const el = $$('div', {class: 'related-articles-container'})
+
+        el.append(
+            $$('div', {class: 'related-articles-heading'}, 'Relaterade artiklar')
+        )
+
+        const articles = this.props.articles
+
+
+
+        if (articles && articles.length) {
+            el.append(this._renderArticles($$, articles))
+        }
+
+        return el
+    }
+
+    _renderArticles($$, articles) {
+        return articles.map(article => {
+            return $$('div', {class: 'related-article'}, [
+                $$('span', {class:'article-icon'},
+                    $$('i', {class: 'fa fa-file-text-o'})
+                ),
+                $$('a', {class: 'article-title', href: `#${article.uuid}`, target: '_blank'}, article.title),
+                $$('button', {class: 'article-remove'},
+                    $$('i', {class: 'fa fa-remove'})
+                ).on('click', () => this.props.remove(article.uuid))
+            ])
+        })
+    }
+}
+
+export default RelatedArticlesComponent

--- a/plugins/se.infomaker.ximteaser/RelatedArticlesComponent.js
+++ b/plugins/se.infomaker.ximteaser/RelatedArticlesComponent.js
@@ -1,20 +1,40 @@
 import { Component } from 'substance'
 
+/**
+ * @typedef RelatedArticlesComponent.Props
+ * @property {RelatedArticlesComponent.Article[]} articles
+ */
+
+/**
+ * @typedef RelatedArticlesComponent.Article
+ * @property {string} title
+ * @property {string} uuid
+ */
+
+/**
+ * Renders a list of links to related articles
+ *
+ * @param {RelatedArticlesComponent.Props} props
+ * @property {RelatedArticlesComponent.Props} props
+ */
 class RelatedArticlesComponent extends Component {
     constructor(...args) {
         super(...args)
     }
 
+    /**
+     * @param {function} $$ - Substance createElement
+     * @returns {VirtualElement}
+     */
     render($$) {
         const el = $$('div', {class: 'related-articles-container'})
 
         el.append(
-            $$('div', {class: 'related-articles-heading'}, 'Relaterade artiklar')
+            $$('div', {class: 'related-articles-heading'}, this.getLabel('teaser-related-articles'))
         )
 
+        /** @type {RelatedArticlesComponent.Article[]} */
         const articles = this.props.articles
-
-
 
         if (articles && articles.length) {
             el.append(this._renderArticles($$, articles))
@@ -23,6 +43,11 @@ class RelatedArticlesComponent extends Component {
         return el
     }
 
+    /**
+     * @param {function} $$ - Substance createElement
+     * @param {RelatedArticlesComponent.Article[]} articles
+     * @returns {VirtualElement}
+     */
     _renderArticles($$, articles) {
         return articles.map(article => {
             return $$('div', {class: 'related-article'}, [

--- a/plugins/se.infomaker.ximteaser/RelatedArticlesComponent.js
+++ b/plugins/se.infomaker.ximteaser/RelatedArticlesComponent.js
@@ -18,9 +18,6 @@ import { Component } from 'substance'
  * @property {RelatedArticlesComponent.Props} props
  */
 class RelatedArticlesComponent extends Component {
-    constructor(...args) {
-        super(...args)
-    }
 
     /**
      * @param {function} $$ - Substance createElement

--- a/plugins/se.infomaker.ximteaser/TeaserComponent.js
+++ b/plugins/se.infomaker.ximteaser/TeaserComponent.js
@@ -1,6 +1,7 @@
 import {ContainerEditor, StrongCommand, EmphasisCommand, SwitchTextCommand, Component, FontAwesomeIcon} from 'substance'
 import {api} from 'writer'
 import FileInputComponent from './FileInputComponent'
+import RelatedArticlesComponent from './RelatedArticlesComponent'
 
 class TeaserComponent extends Component {
 
@@ -55,6 +56,7 @@ class TeaserComponent extends Component {
         const currentType = types.find(({type}) => type === this.props.node.dataType)
         const hasImage = this.props.node.imageFile
         const hasFields = currentType.fields && currentType.fields.length
+        const hasRelatedArticles = this.props.node.relatedArticles && this.props.node.relatedArticles.length
 
         if (hasImage) {
             el.append(this._renderImageDisplay($$, currentType))
@@ -66,6 +68,10 @@ class TeaserComponent extends Component {
             el.append(this._renderEditorFields($$, currentType, hasImage))
         } else {
             el.append($$('span').append('No fields configured for teaser'))
+        }
+
+        if (hasRelatedArticles) {
+            el.append(this._renderRelatedArticles($$))
         }
 
         return el
@@ -157,6 +163,15 @@ class TeaserComponent extends Component {
                     this.props.selectContainer()
                 }
             })
+    }
+
+    _renderRelatedArticles($$) {
+        return $$(RelatedArticlesComponent, {
+            articles: this.props.node.relatedArticles,
+            remove: (uuid) => {
+                this.props.node.removeRelatedArticle(uuid)
+            }
+        })
     }
 
     /**

--- a/plugins/se.infomaker.ximteaser/TeaserComponent.js
+++ b/plugins/se.infomaker.ximteaser/TeaserComponent.js
@@ -224,7 +224,7 @@ class TeaserComponent extends Component {
         const container = $$('div').addClass('x-im-teaser-upload-container')
 
         if(extensionModules && extensionModules.length > 0) {
-            const title = this.props.node.imageFile ? 'Replace Image' : 'Add Image'
+            const title = this.props.node.imageFile ? 'teaser-replace-image' : 'teaser-add-image'
             container.append(
                 $$('span')
                     .addClass('upload-button')
@@ -244,7 +244,7 @@ class TeaserComponent extends Component {
     }
 
     openExtensionDialog(extensionComponent) {
-        const label = this.props.node.imageFile ? 'Replace Image' : 'Add Image'
+        const label = this.props.node.imageFile ? 'teaser-replace-image' : 'teaser-add-image'
         api.ui.showDialog(
             extensionComponent,
             {

--- a/plugins/se.infomaker.ximteaser/TeaserContainerComponent.js
+++ b/plugins/se.infomaker.ximteaser/TeaserContainerComponent.js
@@ -137,8 +137,6 @@ class TeaserContainerComponent extends Component {
         let command
 
         if (dragData.type === 'article') {
-            const {name, uuid} = dragData.uriData
-            console.info('Article dropped!', { uuid, name })
             command = 'ximteaser.insert-article'
         } else {
             command = 'ximteaser.insert-image'

--- a/plugins/se.infomaker.ximteaser/TeaserContainerComponent.js
+++ b/plugins/se.infomaker.ximteaser/TeaserContainerComponent.js
@@ -113,7 +113,13 @@ class TeaserContainerComponent extends Component {
      */
     getDropzoneSpecs() {
         const currentTeaserNode = this._getActiveTeaserNode()
-        const label = currentTeaserNode.imageFile ? 'teaser-replace-image-or-article' : 'teaser-add-image-or-article'
+        const teaserTypes = api.getConfigValue('se.infomaker.ximteaser', 'types', [])
+        const currentType = teaserTypes.find(({type}) => type === currentTeaserNode.dataType)
+        const relatedArticlesEnabled = currentType.enableRelatedArticles === true
+
+        const imageAndArticlelabel = currentTeaserNode.imageFile ? 'teaser-replace-image-or-article' : 'teaser-add-image-or-article'
+        const imageLabel = currentTeaserNode.imageFile ? 'teaser-replace-image' : 'teaser-add-image'
+        const label = relatedArticlesEnabled ? imageAndArticlelabel : imageLabel
 
         return [{
             component: this,

--- a/plugins/se.infomaker.ximteaser/TeaserContainerComponent.js
+++ b/plugins/se.infomaker.ximteaser/TeaserContainerComponent.js
@@ -113,7 +113,7 @@ class TeaserContainerComponent extends Component {
      */
     getDropzoneSpecs() {
         const currentTeaserNode = this._getActiveTeaserNode()
-        const label = currentTeaserNode.imageFile ? 'Replace Image' : 'Add Image'
+        const label = currentTeaserNode.imageFile ? 'teaser-replace-image-or-article' : 'teaser-add-image-or-article'
 
         return [{
             component: this,

--- a/plugins/se.infomaker.ximteaser/TeaserContainerComponent.js
+++ b/plugins/se.infomaker.ximteaser/TeaserContainerComponent.js
@@ -134,7 +134,17 @@ class TeaserContainerComponent extends Component {
      */
     handleDrop(tx, dragState) {
         const dragData = dragStateDataExtractor.extract(dragState)
-        api.editorSession.executeCommand('ximteaser.insert-image', {
+        let command
+
+        if (dragData.type === 'article') {
+            const {name, uuid} = dragData.uriData
+            console.info('Article dropped!', { uuid, name })
+            command = 'ximteaser.insert-article'
+        } else {
+            command = 'ximteaser.insert-image'
+        }
+
+        api.editorSession.executeCommand(command, {
             tx,
             context: {node: this._getActiveTeaserNode()},
             data: dragData

--- a/plugins/se.infomaker.ximteaser/TeaserConverter.js
+++ b/plugins/se.infomaker.ximteaser/TeaserConverter.js
@@ -339,7 +339,7 @@ export default {
 
             return linksElem
         } else {
-            return ""
+            return ''
         }
     },
 

--- a/plugins/se.infomaker.ximteaser/TeaserConverter.js
+++ b/plugins/se.infomaker.ximteaser/TeaserConverter.js
@@ -49,8 +49,19 @@ export default {
             }
         }
 
+        // Handle related article links in teaser
+        const relatedArticleLinksElems = el.findAll('links > link[type="x-im/article"]')
+        const relatedArticles = []
+        relatedArticleLinksElems.forEach(relatedArticleElem => {
+            relatedArticles.push({
+                title: relatedArticleElem.attr('title'),
+                uuid: relatedArticleElem.attr('uuid')
+            })
+        })
+        node.relatedArticles = relatedArticles
+
         // Handle image link in teaser
-        const linkEl = el.find('links > link')
+        const linkEl = el.find('links > link[rel="image"]')
         if (linkEl) {
             node.imageType = linkEl.attr('type')
 
@@ -259,11 +270,24 @@ export default {
 
         el.append(data)
 
-        let fileNode = node.document.get(node.imageFile)
+        const links = this.exportLinks($$, node)
+        el.append(links)
 
+    },
+    /**
+     * The links element contains both the teasers image and related articles
+     *
+     * @param $$
+     * @param {TeaserNode} node
+     * @param {NewsMLExporter} converter
+     * @returns {VirtualElement}
+     */
+    exportLinks: function($$, node) {
         // Links
+        let imageLink = null
+        let fileNode = node.document.get(node.imageFile)
         if (fileNode && fileNode.uuid !== '' && node.uri) {
-            const link = $$('link').attr({
+            imageLink = $$('link').attr({
                 rel: 'image',
                 type: 'x-im/image',
                 uri: node.uri,
@@ -273,32 +297,49 @@ export default {
 
             // Add image data and crops to data
             if(node.width) {
-                linkData.append(
-                    $$('width').append(
-                        String(node.width)
-                    )
-                )
-            }
-            if(node.height) {
-                linkData.append(
-                    $$('height').append(
-                        String(node.height)
-                    )
-                )
+                linkData.append($$('width').append(String(node.width)))
             }
 
-            link.append(linkData)
+            if(node.height) {
+                linkData.append($$('height').append(String(node.height)))
+            }
+
+            imageLink.append(linkData)
 
             if (node.crops) {
                 let cropLinks = $$('links')
                 let imageModule = api.getPluginModule('se.infomaker.ximimage.ximimagehandler')
                 imageModule.exportSoftcropLinks($$, cropLinks, node.crops.crops)
-                link.append(cropLinks)
+                imageLink.append(cropLinks)
+            }
+        }
+
+        let relatedArticleLinks = null
+        if (node.relatedArticles && node.relatedArticles.length) {
+            relatedArticleLinks = node.relatedArticles.map(article => {
+                return $$('link').attr({
+                    rel: 'article',
+                    type: 'x-im/article',
+                    title: article.title,
+                    uuid: article.uuid
+                })
+            })
+        }
+
+        if (relatedArticleLinks || imageLink) {
+            const linksElem = $$('links')
+
+            if (imageLink) {
+                linksElem.append(imageLink)
             }
 
-            el.append(
-                $$('links').append(link)
-            )
+            if (relatedArticleLinks) {
+                linksElem.append(relatedArticleLinks)
+            }
+
+            return linksElem
+        } else {
+            return ""
         }
     },
 

--- a/plugins/se.infomaker.ximteaser/TeaserConverter.js
+++ b/plugins/se.infomaker.ximteaser/TeaserConverter.js
@@ -50,15 +50,17 @@ export default {
         }
 
         // Handle related article links in teaser
-        const relatedArticleLinksElems = el.findAll('links > link[type="x-im/article"]')
-        const relatedArticles = []
-        relatedArticleLinksElems.forEach(relatedArticleElem => {
-            relatedArticles.push({
-                title: relatedArticleElem.attr('title'),
-                uuid: relatedArticleElem.attr('uuid')
+        if(this.isRelatedArticlesEnabled(node.dataType)) {
+            const relatedArticleLinksElems = el.findAll('links > link[type="x-im/article"]')
+            const relatedArticles = []
+            relatedArticleLinksElems.forEach(relatedArticleElem => {
+                relatedArticles.push({
+                    title: relatedArticleElem.attr('title'),
+                    uuid: relatedArticleElem.attr('uuid')
+                })
             })
-        })
-        node.relatedArticles = relatedArticles
+            node.relatedArticles = relatedArticles
+        }
 
         // Handle image link in teaser
         const linkEl = el.find('links > link[rel="image"]')
@@ -112,6 +114,11 @@ export default {
     isMultilineEnabled: function(dataType) {
         const {fields} = this.getConfigForType(dataType)
         return fields.some(({id, multiline}) => id === 'text' && multiline === true)
+    },
+
+    isRelatedArticlesEnabled: function(dataType) {
+        const {enableRelatedArticles} = this.getConfigForType(dataType)
+        return enableRelatedArticles === true
     },
 
     /**
@@ -315,7 +322,7 @@ export default {
         }
 
         let relatedArticleLinks = null
-        if (node.relatedArticles && node.relatedArticles.length) {
+        if (this.isRelatedArticlesEnabled(node.dataType) && node.relatedArticles && node.relatedArticles.length) {
             relatedArticleLinks = node.relatedArticles.map(article => {
                 return $$('link').attr({
                     rel: 'article',

--- a/plugins/se.infomaker.ximteaser/TeaserNode.js
+++ b/plugins/se.infomaker.ximteaser/TeaserNode.js
@@ -34,6 +34,12 @@ class TeaserNode extends Container {
     }
 
     addRelatedArticle(article, tx=null) {
+        const teaserTypes = api.getConfigValue('se.infomaker.ximteaser', 'types', [])
+        const currentType = teaserTypes.find(({type}) => type === this.dataType)
+        const relatedArticlesEnabled = currentType.enableRelatedArticles === true
+
+        if (!relatedArticlesEnabled) { return }
+
         const articles = Array.isArray(this.relatedArticles) ? this.relatedArticles.slice() : []
         const articleAlreadyPresent = articles.filter(a => a.uuid === article.uuid).length > 0
         const isSameArticle = article.uuid === api.newsItem.getGuid()
@@ -62,7 +68,6 @@ class TeaserNode extends Container {
                 tx.set([this.id, 'relatedArticles'], articles)
             })
         }
-
     }
 
     removeRelatedArticle(uuid, tx=null) {

--- a/plugins/se.infomaker.ximteaser/TeaserNode.js
+++ b/plugins/se.infomaker.ximteaser/TeaserNode.js
@@ -155,7 +155,7 @@ TeaserNode.define({
 
     customFields: {type:'object', optional: false, default: {}},
 
-    relatedArticles: {type: 'array', optional: true, defaut: []},
+    relatedArticles: {type: 'array', optional: true, default: []},
 
     width: {type: 'number', optional: true},
     height: {type: 'number', optional: true},

--- a/plugins/se.infomaker.ximteaser/TeaserNode.js
+++ b/plugins/se.infomaker.ximteaser/TeaserNode.js
@@ -33,6 +33,37 @@ class TeaserNode extends Container {
         return imageFile.proxy.fetchSpecifiedUrls(fallbacks)
     }
 
+    addRelatedArticle(article, tx=null) {
+        const articles = Array.isArray(this.relatedArticles) ? this.relatedArticles.slice() : []
+
+        const articleAlreadyPresent = articles.filter(a => a.uuid === article.uuid).length > 0
+
+        if (!articleAlreadyPresent) {
+            articles.push(article)
+
+            if (tx) {
+                tx.set([this.id, 'relatedArticles'], articles)
+            } else {
+                api.editorSession.transaction(tx => {
+                    tx.set([this.id, 'relatedArticles'], articles)
+                })
+            }
+        }
+    }
+
+    removeRelatedArticle(uuid, tx=null) {
+        const articles = Array.isArray(this.relatedArticles) ? this.relatedArticles.slice() : []
+        const remainingArticles = articles.filter(article => article.uuid !== uuid)
+
+        if (tx) {
+            tx.set([this.id, 'relatedArticles'], remainingArticles)
+        } else {
+            api.editorSession.transaction(tx => {
+                tx.set([this.id, 'relatedArticles'], remainingArticles)
+            })
+        }
+    }
+
     setSoftcropData(data, disableAutomaticCrop) {
         api.editorSession.transaction((tx) => {
             tx.set([this.id, 'crops'], data)
@@ -109,6 +140,8 @@ TeaserNode.define({
     text: {type: 'string', optional: false, default: ''},
 
     customFields: {type:'object', optional: false, default: {}},
+
+    relatedArticles: {type: 'array', optional: true, defaut: []},
 
     width: {type: 'number', optional: true},
     height: {type: 'number', optional: true},

--- a/plugins/se.infomaker.ximteaser/TeaserNode.js
+++ b/plugins/se.infomaker.ximteaser/TeaserNode.js
@@ -35,20 +35,34 @@ class TeaserNode extends Container {
 
     addRelatedArticle(article, tx=null) {
         const articles = Array.isArray(this.relatedArticles) ? this.relatedArticles.slice() : []
-
         const articleAlreadyPresent = articles.filter(a => a.uuid === article.uuid).length > 0
+        const isSameArticle = article.uuid === api.newsItem.getGuid()
+        const notificationTitle = api.getLabel('teaser-related-article-not-added')
 
-        if (!articleAlreadyPresent) {
-            articles.push(article)
+        if (articleAlreadyPresent) {
+            const message = api.getLabel('teaser-related-article-already-added')
+                .replace('{title}', article.title)
 
-            if (tx) {
-                tx.set([this.id, 'relatedArticles'], articles)
-            } else {
-                api.editorSession.transaction(tx => {
-                    tx.set([this.id, 'relatedArticles'], articles)
-                })
-            }
+            return api.ui.showNotification(this.type, notificationTitle, message)
         }
+
+        if (isSameArticle) {
+            const message = api.getLabel('teaser-related-article-is-self')
+                .replace('{title}', article.title)
+
+            return api.ui.showNotification(this.type, notificationTitle, message)
+        }
+
+        articles.push(article)
+
+        if (tx) {
+            tx.set([this.id, 'relatedArticles'], articles)
+        } else {
+            api.editorSession.transaction(tx => {
+                tx.set([this.id, 'relatedArticles'], articles)
+            })
+        }
+
     }
 
     removeRelatedArticle(uuid, tx=null) {

--- a/plugins/se.infomaker.ximteaser/TeaserPackage.js
+++ b/plugins/se.infomaker.ximteaser/TeaserPackage.js
@@ -81,5 +81,20 @@ export default {
             en: 'Related articles',
             sv: 'Relaterade artiklar'
         })
+
+        config.addLabel('teaser-related-article-not-added', {
+            en: 'Could not add',
+            sv: 'Kunde inte infoga'
+        })
+
+        config.addLabel('teaser-related-article-already-added', {
+            en: 'The article {title} has already been added to the teaser',
+            sv: 'Artikeln {title} finns redan i teasern'
+        })
+
+        config.addLabel('teaser-related-article-is-self', {
+            en: 'Can not add the article to itself',
+            sv: 'Kan inte infoga artikeln i sig själv'
+        })
     }
 }

--- a/plugins/se.infomaker.ximteaser/TeaserPackage.js
+++ b/plugins/se.infomaker.ximteaser/TeaserPackage.js
@@ -10,6 +10,7 @@ import InsertTeaserCommand from './InsertTeaserCommand'
 import TeaserConverter from './TeaserConverter'
 import TeaserNode from './TeaserNode'
 import InsertTeaserImageCommand from './InsertTeaserImageCommand'
+import InsertTeaserArticleCommand from './InsertTeaserArticleCommand'
 
 import {idGenerator} from 'writer'
 
@@ -46,6 +47,7 @@ export default {
         config.addNode(TeaserNode)
         config.addCommand('ximteaser.insert-teaser', InsertTeaserCommand)
         config.addCommand('ximteaser.insert-image', InsertTeaserImageCommand)
+        config.addCommand('ximteaser.insert-article', InsertTeaserArticleCommand)
 
         config.addLabel('Insert Teaser', {
             sv: 'Infoga puff'
@@ -54,10 +56,10 @@ export default {
             sv: 'Lägg till ny puff'
         })
         config.addLabel('Add Image', {
-            sv: 'Lägg till bild'
+            sv: 'Lägg till bild eller relaterad artikel'
         })
         config.addLabel('Replace Image', {
-            sv: 'Ersätt bild'
+            sv: 'Ersätt bild eller lägg till relaterad artikel'
         })
     }
 }

--- a/plugins/se.infomaker.ximteaser/TeaserPackage.js
+++ b/plugins/se.infomaker.ximteaser/TeaserPackage.js
@@ -62,7 +62,7 @@ export default {
             sv: 'Lägg till bild'
         })
 
-        config.addLabel('Replace Image', {
+        config.addLabel('teaser-replace-image', {
             en: 'Replace image',
             sv: 'Ersätt bild'
         })

--- a/plugins/se.infomaker.ximteaser/TeaserPackage.js
+++ b/plugins/se.infomaker.ximteaser/TeaserPackage.js
@@ -52,14 +52,34 @@ export default {
         config.addLabel('Insert Teaser', {
             sv: 'Infoga puff'
         })
+
         config.addLabel('Add new teaser', {
             sv: 'Lägg till ny puff'
         })
-        config.addLabel('Add Image', {
+
+        config.addLabel('teaser-add-image', {
+            en: 'Add image',
+            sv: 'Lägg till bild'
+        })
+
+        config.addLabel('Replace Image', {
+            en: 'Replace image',
+            sv: 'Ersätt bild'
+        })
+
+        config.addLabel('teaser-add-image-or-article', {
+            en: 'Add image or related article',
             sv: 'Lägg till bild eller relaterad artikel'
         })
-        config.addLabel('Replace Image', {
+
+        config.addLabel('teaser-replace-image-or-article', {
+            en: 'Replace image or add related article',
             sv: 'Ersätt bild eller lägg till relaterad artikel'
+        })
+
+        config.addLabel('teaser-related-articles', {
+            en: 'Related articles',
+            sv: 'Relaterade artiklar'
         })
     }
 }

--- a/plugins/se.infomaker.ximteaser/dragStateDataExtractor.js
+++ b/plugins/se.infomaker.ximteaser/dragStateDataExtractor.js
@@ -80,7 +80,6 @@ export default {
     },
 
     _isUriDrop(dragData) {
-
         return dragData.uris && dragData.uris.length > 0 && this._isValidUri(dragData.uris[0])
     },
 

--- a/plugins/se.infomaker.ximteaser/dragStateDataExtractor.js
+++ b/plugins/se.infomaker.ximteaser/dragStateDataExtractor.js
@@ -18,9 +18,7 @@ export default {
     },
 
     /**
-     * 
-     * 
-     * @param {any} dragState 
+     * @param {any} dragState
      * @param {Boolean} multiple
      */
     _extractData(dragState, multiple) {
@@ -46,6 +44,11 @@ export default {
                 result.type = 'url'
                 result.url = url
             }
+        } else if (this._isArticleDrop(dragState.data)){
+            const uri = dragState.data.uris[0]
+            result.type = 'article'
+            result.uri = uri
+            result.uriData = this._getDataFromURL(uri)
         }
 
         return result
@@ -78,5 +81,10 @@ export default {
 
     _isUriDrop(dragData) {
         return dragData.uris && dragData.uris.length > 0 && dragData.uris[0].includes('x-im-entity://x-im/image')
+    },
+
+
+    _isArticleDrop(dragData) {
+        return dragData.uris && dragData.uris.length > 0 && dragData.uris[0].includes('x-im-entity://x-im/article')
     }
 }

--- a/plugins/se.infomaker.ximteaser/scss/index.scss
+++ b/plugins/se.infomaker.ximteaser/scss/index.scss
@@ -63,6 +63,55 @@
             display: none;
         }
     }
+
+    .related-articles-container {
+        margin-top: 10px;
+
+        .related-articles-heading {
+            font-size: 0.9em;
+            color: #b4b4b4;
+        }
+
+        .related-article {
+            border: 1px solid #eee;
+            background-color: #fff;
+            border-left-width: 6px;
+            border-radius: 2px;
+            margin: 2px 0;
+            padding: 4px 8px;
+            font-size: 0.9em;
+
+            .article-title {
+                margin: 2px 8px;
+            }
+
+            .article-icon {
+                color: #d0d0d0;
+            }
+
+            .article-remove {
+                display: none;
+                float: right;
+                color: #d0d0d0;
+
+                &:hover {
+                    color: #b4b4b4;
+                }
+            }
+        }
+
+        &:hover .article-remove {
+            display: initial;
+        }
+    }
+}
+
+// Style related articles when teaser doesn't have focus
+.sm-selected .related-articles-container .related-article {
+    background-color: #eee;
+    a {
+        color: #b4b4b4;
+    }
 }
 
 .teaser-menu {


### PR DESCRIPTION
Allows the user to drag a related article found by searching in the `contentrelations` plugin and dropping it on the teaser to add it to the teasers `<links>` element. Related articles are shown below the teaser fields.

Issue: [WPLUG-175](https://jira.infomaker.se/browse/WPLUG-175)