### PR TITLE
Feature/wplug 192 image dimensions for image gallery

### DIFF
--- a/plugins/se.infomaker.imagegallery/ImageGalleryConverter.js
+++ b/plugins/se.infomaker.imagegallery/ImageGalleryConverter.js
@@ -71,6 +71,12 @@ const ImageGalleryConverter = {
                         if (child.tagName === 'text') {
                             imageGalleryImage.caption = converter.annotatedText(child, [imageGalleryImage.id, 'caption'])
                         }
+                        if (child.tagName === 'height') {
+                            imageGalleryImage.height = parseInt(child.text(), 10)
+                        }
+                        if (child.tagName === 'width') {
+                            imageGalleryImage.width = parseInt(child.text(), 10)
+                        }
                     })
                 }
 
@@ -153,6 +159,16 @@ const ImageGalleryConverter = {
                 imageData.append($$('text').append(
                     converter.annotatedText([galleryImageNode.id, 'caption'])
                 ))
+            }
+            if(galleryImageNode.height) {
+                imageData.append(
+                    $$('height').append(String(galleryImageNode.height))
+                )
+            }
+            if(galleryImageNode.width) {
+                imageData.append(
+                    $$('width').append(String(galleryImageNode.width))
+                )
             }
 
             link.append(imageData)

--- a/plugins/se.infomaker.imagegallery/ImageGalleryImageNode.js
+++ b/plugins/se.infomaker.imagegallery/ImageGalleryImageNode.js
@@ -206,6 +206,8 @@ ImageGalleryImageNode.define({
     imageFile: {type: 'file', optional: true},
     authors: {type: 'array', default: []},
     caption: {type: 'string', default: ''},
+    width: {type: 'number', optional: true},
+    height: {type: 'number', optional: true}
 })
 
 export default ImageGalleryImageNode

--- a/plugins/se.infomaker.imagegallery/README.md
+++ b/plugins/se.infomaker.imagegallery/README.md
@@ -16,7 +16,7 @@ for sorting images.
 
 ## Output
 ```xml
-<object id="imagegallery-8a52dde8c22e270f0023d2060b0128b4" type="x-im/imagegallery" >
+<object id="imagegallery-8a52dde8c22e270f0023d2060b0128b4" type="x-im/imagegallery">
     <data>
         <text>In sodales lectus vel egestas rhoncus</text>
     </data>

--- a/plugins/se.infomaker.imagegallery/README.md
+++ b/plugins/se.infomaker.imagegallery/README.md
@@ -1,6 +1,6 @@
 # Image Gallery Plugin
 Image Gallery with image preview and toolbox with drag-and-drop support
-for ordering images.
+for sorting images.
 
 ## Plugin configuration
 ```json
@@ -18,18 +18,14 @@ for ordering images.
 ```xml
 <object id="imagegallery-8a52dde8c22e270f0023d2060b0128b4" type="x-im/imagegallery" >
     <data>
-        <!--
-            caption on gallery level is an "optional" element used as an "generic caption" for all
-            of the images in the gallery
-        -->
-        <caption>In sodales lectus vel egestas rhoncus</caption>
+        <text>In sodales lectus vel egestas rhoncus</text>
     </data>
     <links>
-        <link rel="image" type="x-im/image"
-            uri="im://image/znX8U1CU124n26zu7gb40_jBzSk.jpeg"
-            uuid="c382c937-8511-5d48-9677-55658c2bbb32">
+        <link rel="image" type="x-im/image" uri="im://image/znX8U1CU124n26zu7gb40_jBzSk.jpeg" uuid="c382c937-8511-5d48-9677-55658c2bbb32">
             <data>
-                <caption>Image caption</caption>
+                <text>Image caption</text>
+                <height>200</height>
+                <width>400</width>
                 <links>
                     <link rel="author" uuid="7a39b42b-1315-4711-a136-7b3a9f132110" title="Demo Demosson" type="x-im/author">
                         <data>
@@ -51,3 +47,4 @@ for ordering images.
 </object>
 ```
 
+**Note** that `object > data > text` is optional and will only render if it has a value.

--- a/plugins/se.infomaker.imagegallery/components/ImageGalleryImageComponent.js
+++ b/plugins/se.infomaker.imagegallery/components/ImageGalleryImageComponent.js
@@ -40,13 +40,17 @@ class ImageGalleryImageComponent extends Component {
             fetchImageMeta(imageNode.uuid)
                 .then((node) => {
                     this.context.editorSession.transaction((tx) => {
-                        tx.set([this.props.node.id, 'caption'], node.caption)
+                        if (!node.caption) {
+                            tx.set([this.props.node.id, 'caption'], node.caption)
+                        }
                         if (node.authors.length > 0) {
                             tx.set([this.props.node.id, 'authors'], node.authors)
                         }
-                        if(!imageNode.uri) {
+                        if (!imageNode.uri) {
                             tx.set([imageNode.id, 'uri'], node.uri)
                         }
+                        tx.set([this.props.node.id, 'width'], node.width)
+                        tx.set([this.props.node.id, 'height'], node.height)
                     })
                     this.rerender()
                 })


### PR DESCRIPTION
### Bild-dimensioner för bildgalleriets xml-output

Hämtar width och height från binär-meta och populerar properties på ImageGalleryImageNode.
Exempel-output efter fix:

```xml
<object id="imagegallery-8a52dde8c22e270f0023d2060b0128b4" type="x-im/imagegallery">
    <data>
        <text>In sodales lectus vel egestas rhoncus</text>
    </data>
    <links>
        <link rel="image" type="x-im/image" uri="im://image/znX8U1CU124n26zu7gb40_jBzSk.jpeg" uuid="c382c937-8511-5d48-9677-55658c2bbb32">
            <data>
                <text>Image caption</text>
                <height>200</height>
                <width>400</width>
            </data>
        </link>
    </links>
</object>
```