### PR TITLE
Added support for label

### DIFF
--- a/plugins/se.infomaker.options/OptionsComponent.js
+++ b/plugins/se.infomaker.options/OptionsComponent.js
@@ -100,6 +100,11 @@ class OptionsComponent extends Component {
                 }
             }
             else {
+
+                if (selectedOption.label === true) {
+                    return
+                }
+
                 this.context.api.newsItem.addContentMetaLink(this.pluginName, {
                     '@rel': selectedOption.rel || selectedList.link.rel,
                     '@title': selectedOption.title,
@@ -109,6 +114,11 @@ class OptionsComponent extends Component {
             }
         } else {
             this.clearContentMetaLinks(selectedList)
+
+            if (selectedOption.label === true) {
+                return
+            }
+
             if (!found) {
                 this.context.api.newsItem.addContentMetaLink(this.pluginName, {
                     '@rel': selectedOption.rel || selectedList.link.rel,

--- a/plugins/se.infomaker.options/OptionsComponent.js
+++ b/plugins/se.infomaker.options/OptionsComponent.js
@@ -138,6 +138,7 @@ class OptionsComponent extends Component {
     /**
      * Responsible for reporting whether a specific list data element is selected or not
      *
+     * @param list
      * @param data The element to check
      * @return True if selected, false otherwise
      */

--- a/plugins/se.infomaker.options/README.md
+++ b/plugins/se.infomaker.options/README.md
@@ -21,6 +21,10 @@ of options to choose from.
         "multivalue": false,
         "values": [
             {
+                "title": "Select article option",
+                "label": true
+            },
+            {
                 "uri": "im://articleoptions/premium",
                 "title": "Premium"
             },
@@ -116,12 +120,18 @@ The dropdown component, configured with **dropdown** supports selecting a single
           },
           "multivalue": false,
           "values": [
+            { 
+              "title": "-- Choose something --",
+              "label": true
+            }, 
             {
               "uri": "im://articleoptions/premium",
               "title": "Premium"
             },
             ...
 ```
+
+If `"label":true` is set for an item in `values`, the item is considered being a label an does not generate a link in the NewsML. 
 
 ### Button
 The button component, configured with **button** stacks horizontally and supports selecting multiple values: 

--- a/plugins/se.infomaker.options/README.md
+++ b/plugins/se.infomaker.options/README.md
@@ -6,80 +6,83 @@ Options are specified, in the writer client configuration file, as a specific ty
 of options to choose from.
 ```json
 {
-    "id": "se.infomaker.options",
-    "name": "options",
-    "url": "https://plugins.writer.infomaker.io/releases/{PLUGIN_VERSION}/im-options.js",
-    "enabled": true,
-    "mandatory": true,
-    "data": {"options": {
-        "type": "dropdown",
-        "label": "Article options",
-        "link": {
-            "rel": "articleoptions",
-            "type": "x-im/articleoptions"
+  "id": "se.infomaker.options",
+  "name": "options",
+  "url": "https://plugins.writer.infomaker.io/releases/{PLUGIN_VERSION}/im-options.js",
+  "enabled": true,
+  "mandatory": true,
+  "data": {
+    "options": {
+      "type": "dropdown",
+      "label": "Article options",
+      "link": {
+        "rel": "articleoptions",
+        "type": "x-im/articleoptions"
+      },
+      "multivalue": false,
+      "values": [
+        {
+          "title": "Select article option",
+          "label": true
         },
-        "multivalue": false,
-        "values": [
-            {
-                "title": "Select article option",
-                "label": true
+        {
+          "uri": "im://articleoptions/premium",
+          "title": "Premium"
+        },
+        {
+          "uri": "im://articleoptions/facebok",
+          "title": "Facebook"
+        },
+        {
+          "uri": "im://articleoptions/instagram",
+          "title": "Instagram"
+        },
+        {
+          "title": "Article tone",
+          "uri": "im://articleoptions/tone",
+          "list": {
+            "type": "toggle",
+            "label": "Article tone options",
+            "link": {
+              "rel": "articleoptions/tone",
+              "type": "x-im/articleoptions/tone"
             },
-            {
-                "uri": "im://articleoptions/premium",
-                "title": "Premium"
-            },
-            {
-                "uri": "im://articleoptions/facebok",
-                "title": "Facebook"
-            },
-            {
-                "uri": "im://articleoptions/instagram",
-                "title": "Instagram"
-            },
-            {
-                "title": "Article tone",
-                "uri": "im://articleoptions/tone",
-                "list": {
-                    "type": "toggle",
-                    "label": "Article tone options",
-                    "link": {
-                        "rel": "articleoptions/tone",
-                        "type": "x-im/articleoptions/tone"
-                    },
-                    "multivalue": true,
-                    "values": [
-                        {
-                            "uri": "im://articleoptions/tone/positive",
-                            "title": "Positive tone"
-                        },
-                        {
-                            "uri": "im://articleoptions/tone/neutral",
-                            "title": "Neutral tone"
-                        },
-                        {
-                            "uri": "im://articleoptions/tone/negative",
-                            "title": "Negative tone"
-                        }
-                    ]
-                }
-            }
-        ]
-    }}
+            "multivalue": true,
+            "values": [
+              {
+                "uri": "im://articleoptions/tone/positive",
+                "title": "Positive tone"
+              },
+              {
+                "uri": "im://articleoptions/tone/neutral",
+                "title": "Neutral tone"
+              },
+              {
+                "uri": "im://articleoptions/tone/negative",
+                "title": "Negative tone"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
 }
 ```
-he example above states a dropdown list with 4 selectable items.
-The multivalue options is set to false, which means that only one value may be selected.
-The fourth option 'Article tone' has a sub-list defined with three options.
-It's a toggle style and since multivalue is set to true, it is possible to select any number of these options.
+The example above states a dropdown list with 4 selectable items.
+* The multivalue options is set to false, which means that only one value may be selected.
+* The fourth option `"Article tone"` has a sub-list defined with three options.
+* It's a toggle style and since multivalue is set to true, it is possible to select any number of these options.
 
 
+### Multiple Options Definitions
 The option plugin supports being defined multiple times in the configuration file so that
 completely different options may be handled by this plugin. *The id must be set to different values
 in order for this to function. The name must be set to **options** in order for plugin to register*.
 
 Also, **the URL must be unique** in order for the plugin to load multiple times. This can be achieved
 by appending "?..." to the URL. 
-```
+```json
 {
     "id": "se.infomaker.socialoptions",
     "name": "options",
@@ -109,29 +112,29 @@ The dropdown component, configured with **dropdown** supports selecting a single
     ------------------------
 
 #### Example configuration
-```
+```json
 ...
- "options": {
-          "type": "dropdown",
-          "label": "Article options",
-          "link": {
-            "rel": "articleoptions",
-            "type": "x-im/articleoptions"
-          },
-          "multivalue": false,
-          "values": [
-            { 
-              "title": "-- Choose something --",
-              "label": true
-            }, 
-            {
-              "uri": "im://articleoptions/premium",
-              "title": "Premium"
-            },
-            ...
+"options": {
+    "type": "dropdown",
+    "label": "Article options",
+    "link": {
+        "rel": "articleoptions",
+        "type": "x-im/articleoptions"
+    },
+    "multivalue": false,
+    "values": [
+        { 
+            "title": "-- Choose something --",
+            "label": true
+        }, 
+        {
+            "uri": "im://articleoptions/premium",
+            "title": "Premium"
+        },
+...
 ```
 
-If `"label":true` is set for an item in `values`, the item is considered being a label an does not generate a link in the NewsML. 
+If `"label": true` is set for an item in `values`, the item is considered a label and does not generate a link in the NewsML. 
 
 ### Button
 The button component, configured with **button** stacks horizontally and supports selecting multiple values: 
@@ -140,33 +143,34 @@ The button component, configured with **button** stacks horizontally and support
     [Value 4]
     
 Buttons also have support for icons prepending the name. It is configured in the 'values' section, using the field 'icon'. The value
-is any of the Font Awesome icons from http://fontawesome.io/icons/.
+is any of the [Font Awesome Icons](http://fontawesome.io/icons/).
 
-It is also possible to have an image icon, which is specified using the 'image' field in the value section.    
+It is also possible to have an image icon, which is specified using the 'image' field in the value section.
+The value must be a base64-encoded string of the image.
 
 #### Example configuration
-```
+```json
 ...
- "options": {
-          "type": "button",
-          "label": "Article options",
-          "link": {
-            "rel": "articleoptions",
-            "type": "x-im/articleoptions"
-          },
-          "multivalue": true,
-          "values": [
-            {
-              "uri": "im://articleoptions/premium",
-              "title": "Premium",
-              "icon" : "fa-star-o"
-            },
-            {
-              "uri": "im://articleoptions/priority",
-              "title": "Priority",
-              "image" : "data:image/svg+xml;base64,..."
-            },                    
-            ...
+"options": {
+    "type": "button",
+    "label": "Article options",
+    "link": {
+        "rel": "articleoptions",
+        "type": "x-im/articleoptions"
+    },
+    "multivalue": true,
+    "values": [
+        {
+            "uri": "im://articleoptions/premium",
+            "title": "Premium",
+            "icon" : "fa-star-o"
+        },
+        {
+            "uri": "im://articleoptions/priority",
+            "title": "Priority",
+            "image" : "data:image/svg+xml;base64,..."
+        },
+...
 ```
     
 ### Toggle
@@ -178,33 +182,34 @@ The toggle component, configured with **toggle** stacks vertically and supports 
 ``` 
     
 Toggle buttons also have support for icons prepending the title. It is configured in the 'values' section, using the field 'icon'. The value
-is any of the Font Awesome icons from http://fontawesome.io/icons/.
+is any of the [Font Awesome Icons](http://fontawesome.io/icons/).
 
-It is also possible to have an image icon, which is specified using the 'image' field in the value section.    
+It is also possible to have an image icon, which is specified using the 'image' field in the value section.
+The value must be a base64-encoded string of the image.    
         
 #### Example configuration
-```
+```json
 ...
- "options": {
-          "type": "toggle",
-          "label": "Article options",
-          "link": {
-            "rel": "articleoptions",
-            "type": "x-im/articleoptions"
-          },
-          "multivalue": true,
-          "values": [
-            {
-              "uri": "im://articleoptions/premium",
-              "title": "Premium",
-              "icon" : "fa-star-o"
-            },
-            {
-              "uri": "im://articleoptions/priority",
-              "title": "Priority",
-              "image" : "data:image/svg+xml;base64,..."
-            },                    
-            ...
+"options": {
+    "type": "toggle",
+    "label": "Article options",
+    "link": {
+        "rel": "articleoptions",
+        "type": "x-im/articleoptions"
+    },
+    "multivalue": true,
+    "values": [
+        {
+            "uri": "im://articleoptions/premium",
+            "title": "Premium",
+            "icon" : "fa-star-o"
+        },
+        {
+            "uri": "im://articleoptions/priority",
+            "title": "Priority",
+            "image" : "data:image/svg+xml;base64,..."
+        },
+...
  ```    
 
 ## Output


### PR DESCRIPTION
This fix adds support for items that may be of type 'label' which do not generate
a link in NewsML. The fix makes most sense for dropdowns