### PR TITLE
Feature/wplug 199 image info for gallery

### DIFF
--- a/plugins/se.infomaker.imagegallery/ImageGalleryConverter.js
+++ b/plugins/se.infomaker.imagegallery/ImageGalleryConverter.js
@@ -131,7 +131,7 @@ const ImageGalleryConverter = {
                     Object.keys(softCrop)
                         .filter(key => key !== 'name')
                         .forEach((key) => {
-                            softCrop[key] = parseFloat(softCrop.x)
+                            softCrop[key] = parseFloat(softCrop[key])
                         })
                     return softCrop
                 })

--- a/plugins/se.infomaker.imagegallery/ImageGalleryPackage.js
+++ b/plugins/se.infomaker.imagegallery/ImageGalleryPackage.js
@@ -29,6 +29,7 @@ const ImageGalleryPackage = {
         config.addIcon('angle-right', { 'fontawesome': 'fa-angle-right' })
         config.addIcon('remove', { 'fontawesome': 'fa-times' })
         config.addIcon('crop', {'fontawesome': 'fa-crop'})
+        config.addIcon('info', {'fontawesome': 'fa-info'})
 
         /* Labels */
         config.addLabel('remove-image-button-title', {
@@ -38,6 +39,10 @@ const ImageGalleryPackage = {
         config.addLabel('crop-image-button-title', {
             en: 'Crop image',
             sv: 'Beskär bild'
+        })
+        config.addLabel('info-image-button-title', {
+            en: 'Archive information',
+            sv: 'Arkivinformation'
         })
         config.addLabel('im-imagegallery.image-gallery-name', {
             en: 'Image gallery',
@@ -61,6 +66,9 @@ const ImageGalleryPackage = {
         })
         config.addLabel('crops defined', {
             sv: 'beskärningar valda'
+        })
+        config.addLabel('Image archive information', {
+            sv: 'Arkivinformation om bild'
         })
     }
 }

--- a/plugins/se.infomaker.imagegallery/README.md
+++ b/plugins/se.infomaker.imagegallery/README.md
@@ -13,6 +13,7 @@ for sorting images.
   "mandatory": false,
   "data": {
     "cropsEnabled": true,
+    "imageInfoEnabled": true,
     "crops": {
       "16:9": [16, 9],
       "8:5": [8, 5],
@@ -25,10 +26,11 @@ for sorting images.
 
 ### Options
 
-| Property          | Type      | Required  | Description  |
-| --------          | :--:      | :------:  | -----------  |
-| **cropsEnabled**  | Boolean   | `false`   | The soft crop dialog is hidden by default. Set `cropsEnabled` to `true` to enable. Default `false`. |
-| **crops**         | Object    | `false`   | *Required if crops is enabled.<br>Expressed as an object of named ratios. The value for each named dimension is an array of the width and height ratio. |
+| Property              | Type      | Required  | Description  |
+| --------              | :--:      | :------:  | -----------  |
+| **cropsEnabled**      | Boolean   | `false`   | The soft crop dialog is hidden by default. Set `cropsEnabled` to `true` to enable. Default `false`. |
+| **imageInfoEnabled**  | Boolean   | `false`   | Adds ability to display archive information for image. Set `imageInfoEnabled` to `true` to enable. Default `false`. |
+| **crops**             | Object    | `false`   | *Required if crops is enabled.<br>Expressed as an object of named ratios. The value for each named dimension is an array of the width and height ratio. |
 
 ## Output
 ```xml

--- a/plugins/se.infomaker.imagegallery/components/ImageGalleryComponent.js
+++ b/plugins/se.infomaker.imagegallery/components/ImageGalleryComponent.js
@@ -66,8 +66,11 @@ class ImageGalleryComponent extends Component {
                 cropsEnabled: this._cropsEnabled,
                 removeImage: this._removeImage.bind(this),
                 initialPosition: this._storedGalleryPosition,
-                openCrops: (galleryImageNode) => {
+                onCropsClick: (galleryImageNode) => {
                     this._openCropper($$, galleryImageNode)
+                },
+                onInfoClick: (galleryImageNode) => {
+                    this._openMetaData(galleryImageNode)
                 },
                 onTransitionEnd: (pos) => {
                     this._storedGalleryPosition = pos
@@ -167,6 +170,9 @@ class ImageGalleryComponent extends Component {
                         },
                         onCropClick: () => {
                             this._openCropper($$, galleryImageNode)
+                        },
+                        onInfoClick: () => {
+                            this._openMetaData(galleryImageNode)
                         }
                     }).ref(galleryImageNodeId))
                 })
@@ -270,6 +276,34 @@ class ImageGalleryComponent extends Component {
                     type: 'error',
                     message: `${this.getLabel('The image doesn\'t seem to be available just yet. Please wait a few seconds and try again.')}\n\n${err}`
                 }])
+            })
+    }
+
+    /**
+     * Show image meta data in a modal dialog
+     *
+     * @memberof ImageDisplay
+     */
+    _openMetaData(galleryImageNode) {
+        const imageNode = this.context.api.doc.get(galleryImageNode.imageFile)
+        api.router.getNewsItem(imageNode.uuid, 'x-im/image')
+            .then(response => {
+                api.ui.showDialog(
+                    this.getComponent('dialog-image'),
+                    {
+                        node: imageNode,
+                        url: imageNode.getUrl(),
+                        newsItem: response,
+                        disablebylinesearch: false
+                    },
+                    {
+                        title: this.getLabel('Image archive information'),
+                        global: true,
+                        primary: this.getLabel('Save'),
+                        secondary: this.getLabel('Cancel'),
+                        cssClass: 'np-image-dialog'
+                    }
+                )
             })
     }
 

--- a/plugins/se.infomaker.imagegallery/components/ImageGalleryComponent.js
+++ b/plugins/se.infomaker.imagegallery/components/ImageGalleryComponent.js
@@ -64,6 +64,7 @@ class ImageGalleryComponent extends Component {
                 node: this.props.node,
                 isolatedNodeState: this.props.isolatedNodeState,
                 cropsEnabled: this._cropsEnabled,
+                imageInfoEnabled: this._imageInfoEnabled,
                 removeImage: this._removeImage.bind(this),
                 initialPosition: this._storedGalleryPosition,
                 onCropsClick: (galleryImageNode) => {
@@ -119,6 +120,8 @@ class ImageGalleryComponent extends Component {
     }
 
     /**
+     * Gets crops value from configuration
+     *
      * @returns {Array}
      * @private
      */
@@ -127,11 +130,23 @@ class ImageGalleryComponent extends Component {
     }
 
     /**
+     * Gets cropsEnabled value from configuration
+     *
      * @returns {boolean}
      * @private
      */
     get _cropsEnabled() {
         return this.context.api.getConfigValue('se.infomaker.imagegallery', 'cropsEnabled', false)
+    }
+
+    /**
+     * Gets imageInfoEnabled value from configuration
+     *
+     * @returns {*}
+     * @private
+     */
+    get _imageInfoEnabled() {
+        return this.context.api.getConfigValue('se.infomaker.imagegallery', 'imageInfoEnabled', false)
     }
 
     /**
@@ -156,6 +171,7 @@ class ImageGalleryComponent extends Component {
                         node: galleryImageNode,
                         isolatedNodeState: this.props.isolatedNodeState,
                         cropsEnabled: this._cropsEnabled,
+                        imageInfoEnabled: this._imageInfoEnabled,
                         configuredCrops: this._configuredCrops,
                         remove: () => {
                             this._removeImage(galleryImageNodeId)

--- a/plugins/se.infomaker.imagegallery/components/ImageGalleryImageComponent.js
+++ b/plugins/se.infomaker.imagegallery/components/ImageGalleryImageComponent.js
@@ -127,13 +127,18 @@ class ImageGalleryImageComponent extends Component {
                     .addClass('image-control crop-badge')
                     .addClass(cropBadgeClass)
                     .attr('title', `${currentCrops}/${definedCrops} ${this.getLabel('crops defined')}`),
-                $$('i').addClass('image-control fa fa-info')
-                    .attr('title', this.getLabel('Image archive information'))
-                    .on('click', this.props.onInfoClick),
                 $$('i').addClass('image-control fa fa-crop')
                     .attr('title', this.getLabel('crop-image-button-title'))
                     .on('click', this.props.onCropClick)
             ])
+        }
+
+        if(this.props.imageInfoEnabled === true) {
+            imageControls.append(
+                $$('i').addClass('image-control fa fa-info')
+                    .attr('title', this.getLabel('Image archive information'))
+                    .on('click', this.props.onInfoClick)
+            )
         }
 
         imageControls.append(

--- a/plugins/se.infomaker.imagegallery/components/ImageGalleryImageComponent.js
+++ b/plugins/se.infomaker.imagegallery/components/ImageGalleryImageComponent.js
@@ -41,7 +41,7 @@ class ImageGalleryImageComponent extends Component {
             fetchImageMeta(imageNode.uuid)
                 .then((node) => {
                     this.context.editorSession.transaction((tx) => {
-                        if (!node.caption) {
+                        if (!imageNode.caption) {
                             tx.set([this.props.node.id, 'caption'], node.caption)
                         }
                         if (node.authors.length > 0) {
@@ -91,7 +91,10 @@ class ImageGalleryImageComponent extends Component {
                     .addClass('image-control crop-badge')
                     .addClass(cropBadgeClass)
                     .attr('title', `${currentCrops}/${definedCrops} ${this.getLabel('crops defined')}`),
-                $$('i').addClass('image-control crop-image fa fa-crop')
+                $$('i').addClass('image-control fa fa-info')
+                    .attr('title', this.getLabel('Image archive information'))
+                    .on('click', this.props.onInfoClick),
+                $$('i').addClass('image-control fa fa-crop')
                     .attr('title', this.getLabel('crop-image-button-title'))
                     .on('click', this.props.onCropClick)
             ])

--- a/plugins/se.infomaker.imagegallery/components/ImageGalleryImageComponent.js
+++ b/plugins/se.infomaker.imagegallery/components/ImageGalleryImageComponent.js
@@ -70,6 +70,42 @@ class ImageGalleryImageComponent extends Component {
         const imageWrapper = $$('div').addClass('image-wrapper')
         const imageNode = this.context.doc.get(this.props.node.imageFile)
         const imageEl = $$('img', {src: imageNode.getUrl()}).attr('draggable', false)
+        const imageControls = this._renderImageControls($$)
+
+        imageWrapper.append(imageEl)
+        numberDisplay.append(this.props.index + 1)
+
+        // When clicking on dragAnchor, set draggable on itemWrapper
+        // effectively dragging the wrapper using one of its child elements
+        const dragAnchor = $$('div')
+            .html(this._getSvg())
+            .addClass('drag-me')
+            .on('mousedown', () => this.refs.itemWrapper.attr('draggable', true))
+            .on('mouseup', () => this.refs.itemWrapper.attr('draggable', false))
+
+        itemWrapper
+            .attr('id', `index_${this.props.node.id}`)
+            .attr('draggable', false)
+            .on('dragenter', this._dragEnter)
+            .on('dragleave', this._dragLeave)
+            .on('dragover', this._dragOver)
+            .on('dragstart', this._dragStart)
+            .on('dragend', this._dragEnd)
+
+        return itemWrapper
+            .append(dragAnchor)
+            .append(numberDisplay)
+            .append(imageWrapper)
+            .append(this._renderImageMeta($$))
+            .append(imageControls)
+    }
+
+    /**
+     * @param $$
+     * @returns {VirtualElement}
+     * @private
+     */
+    _renderImageControls($$) {
         const imageControls = $$('div').addClass('image-controls')
 
         if (this.props.cropsEnabled === true) {
@@ -106,32 +142,8 @@ class ImageGalleryImageComponent extends Component {
                 .on('click', this.props.remove)
         )
 
-        imageWrapper.append(imageEl)
-        numberDisplay.append(this.props.index + 1)
 
-        // When clicking on dragAnchor, set draggable on itemWrapper
-        // effectively dragging the wrapper using one of its child elements
-        const dragAnchor = $$('div')
-            .html(this._getSvg())
-            .addClass('drag-me')
-            .on('mousedown', () => this.refs.itemWrapper.attr('draggable', true))
-            .on('mouseup', () => this.refs.itemWrapper.attr('draggable', false))
-
-        itemWrapper
-            .attr('id', `index_${this.props.node.id}`)
-            .attr('draggable', false)
-            .on('dragenter', this._dragEnter)
-            .on('dragleave', this._dragLeave)
-            .on('dragover', this._dragOver)
-            .on('dragstart', this._dragStart)
-            .on('dragend', this._dragEnd)
-
-        return itemWrapper
-            .append(dragAnchor)
-            .append(numberDisplay)
-            .append(imageWrapper)
-            .append(this._renderImageMeta($$))
-            .append(imageControls)
+        return imageControls
     }
 
     /**

--- a/plugins/se.infomaker.imagegallery/components/ImageGalleryPreviewComponent.js
+++ b/plugins/se.infomaker.imagegallery/components/ImageGalleryPreviewComponent.js
@@ -40,12 +40,13 @@ class ImageGalleryPreviewComponent extends Component {
             const imageContainer = $$('div').addClass('image-container')
             const imageControls = $$('div').addClass('preview-image-controls')
 
+
             imageControls.append(
-                $$(Button, {icon: 'remove'})
-                    .addClass('remove-image-button')
-                    .attr('title', this.getLabel('remove-image-button-title'))
+                $$(Button, {icon: 'info'})
+                    .addClass('info-image-button')
+                    .attr('title', this.getLabel('Image archive information'))
                     .on('click', () => {
-                        this.props.removeImage(galleryImageNodeId)
+                        this.props.onInfoClick(galleryImageNode)
                     })
             )
 
@@ -55,10 +56,19 @@ class ImageGalleryPreviewComponent extends Component {
                         .addClass('crop-image-button')
                         .attr('title', this.getLabel('crop-image-button-title'))
                         .on('click', () => {
-                            this.props.openCrops(galleryImageNode)
+                            this.props.onCropsClick(galleryImageNode)
                         })
                 )
             }
+
+            imageControls.append(
+                $$(Button, {icon: 'remove'})
+                    .addClass('remove-image-button')
+                    .attr('title', this.getLabel('remove-image-button-title'))
+                    .on('click', () => {
+                        this.props.removeImage(galleryImageNodeId)
+                    })
+            )
 
             imageContainer.append(imageControls)
 

--- a/plugins/se.infomaker.imagegallery/components/ImageGalleryPreviewComponent.js
+++ b/plugins/se.infomaker.imagegallery/components/ImageGalleryPreviewComponent.js
@@ -136,14 +136,16 @@ class ImageGalleryPreviewComponent extends Component {
     _renderImageControls($$, galleryImageNode) {
         const imageControls = $$('div').addClass('preview-image-controls')
 
-        imageControls.append(
-            $$(Button, {icon: 'info'})
-                .addClass('info-image-button')
-                .attr('title', this.getLabel('Image archive information'))
-                .on('click', () => {
-                    this.props.onInfoClick(galleryImageNode)
-                })
-        )
+        if(this.props.imageInfoEnabled === true) {
+            imageControls.append(
+                $$(Button, {icon: 'info'})
+                    .addClass('info-image-button')
+                    .attr('title', this.getLabel('Image archive information'))
+                    .on('click', () => {
+                        this.props.onInfoClick(galleryImageNode)
+                    })
+            )
+        }
 
         if (this.props.cropsEnabled === true) {
             imageControls.append(

--- a/plugins/se.infomaker.imagegallery/components/ImageGalleryPreviewComponent.js
+++ b/plugins/se.infomaker.imagegallery/components/ImageGalleryPreviewComponent.js
@@ -38,37 +38,7 @@ class ImageGalleryPreviewComponent extends Component {
         const galleryImages = this.props.node.nodes.map((galleryImageNodeId) => {
             const galleryImageNode = this.context.doc.get(galleryImageNodeId)
             const imageContainer = $$('div').addClass('image-container')
-            const imageControls = $$('div').addClass('preview-image-controls')
-
-
-            imageControls.append(
-                $$(Button, {icon: 'info'})
-                    .addClass('info-image-button')
-                    .attr('title', this.getLabel('Image archive information'))
-                    .on('click', () => {
-                        this.props.onInfoClick(galleryImageNode)
-                    })
-            )
-
-            if (this.props.cropsEnabled === true) {
-                imageControls.append(
-                    $$(Button, {icon: 'crop'})
-                        .addClass('crop-image-button')
-                        .attr('title', this.getLabel('crop-image-button-title'))
-                        .on('click', () => {
-                            this.props.onCropsClick(galleryImageNode)
-                        })
-                )
-            }
-
-            imageControls.append(
-                $$(Button, {icon: 'remove'})
-                    .addClass('remove-image-button')
-                    .attr('title', this.getLabel('remove-image-button-title'))
-                    .on('click', () => {
-                        this.props.removeImage(galleryImageNodeId)
-                    })
-            )
+            const imageControls = this._renderImageControls($$, galleryImageNode)
 
             imageContainer.append(imageControls)
 
@@ -155,6 +125,47 @@ class ImageGalleryPreviewComponent extends Component {
         if (this.props.onTransitionEnd) {
             this.props.onTransitionEnd(this.leftPosition)
         }
+    }
+
+    /**
+     * @param $$
+     * @param galleryImageNode
+     * @returns {VirtualElement}
+     * @private
+     */
+    _renderImageControls($$, galleryImageNode) {
+        const imageControls = $$('div').addClass('preview-image-controls')
+
+        imageControls.append(
+            $$(Button, {icon: 'info'})
+                .addClass('info-image-button')
+                .attr('title', this.getLabel('Image archive information'))
+                .on('click', () => {
+                    this.props.onInfoClick(galleryImageNode)
+                })
+        )
+
+        if (this.props.cropsEnabled === true) {
+            imageControls.append(
+                $$(Button, {icon: 'crop'})
+                    .addClass('crop-image-button')
+                    .attr('title', this.getLabel('crop-image-button-title'))
+                    .on('click', () => {
+                        this.props.onCropsClick(galleryImageNode)
+                    })
+            )
+        }
+
+        imageControls.append(
+            $$(Button, {icon: 'remove'})
+                .addClass('remove-image-button')
+                .attr('title', this.getLabel('remove-image-button-title'))
+                .on('click', () => {
+                    this.props.removeImage(galleryImageNode.id)
+                })
+        )
+
+        return imageControls
     }
 
     /**

--- a/plugins/se.infomaker.imagegallery/scss/image-gallery-toolbox.scss
+++ b/plugins/se.infomaker.imagegallery/scss/image-gallery-toolbox.scss
@@ -107,12 +107,15 @@
                         margin-top: 5px;
                     }
                     .author-element {
-                        i {
+                        .fa-times-circle {
                             margin: 0;
                         }
                     }
                 }
                 .image-controls {
+                    display: flex;
+                    height: 25px;
+                    align-items: center;
                     .image-control {
                         display: inline-block;
                         margin: 0 0 0 10px;
@@ -122,12 +125,7 @@
                         &:hover {
                             color: #777;
                         }
-                        &.crop-image {
-                            right: 15px;
-                        }
                         &.crop-badge {
-                            right: 40px;
-                            top: 2px;
                             height: 20px;
                             line-height: 20px;
                             padding: 0;

--- a/plugins/se.infomaker.imagegallery/scss/image-gallery-toolbox.scss
+++ b/plugins/se.infomaker.imagegallery/scss/image-gallery-toolbox.scss
@@ -107,6 +107,9 @@
                         margin-top: 5px;
                     }
                     .author-element {
+                        .avatar {
+                            pointer-events: none;
+                        }
                         .fa-times-circle {
                             margin: 0;
                         }

--- a/plugins/se.infomaker.imagegallery/scss/image-gallery.scss
+++ b/plugins/se.infomaker.imagegallery/scss/image-gallery.scss
@@ -68,30 +68,29 @@
                 float: left;
                 margin-right: 2px;
 
-                &:hover {
-                    button {
-                        display: inline;
-                    }
+                &:hover .preview-image-controls button {
+                    display: inline-block;
                 }
 
-                button {
-                    display: none;
-                    color: #ccc;
+                .preview-image-controls {
                     position: absolute;
                     right: 5px;
                     top: 3px;
 
-                    &:hover i {
+                    button {
+                        display: none;
                         color: #fff;
-                        text-shadow: 0 0 1px #222;
-                    }
-                    &.crop-image-button {
-                        right: 25px;
-                    }
-                    i {
-                        margin: 0;
-                        text-shadow: 0 0 1px #000;
-                        transition: text-shadow 0.1s ease-in, color 0.1s ease-in;
+                        margin-left: 10px;
+
+                        i {
+                            margin: 0;
+                            text-shadow: 0 0 1px #000;
+                            transition: text-shadow 0.1s ease-in, color 0.1s ease-in;
+                        }
+                        &:hover i {
+                            color: #ddd;
+                            text-shadow: 0 0 1px #222;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This adds the image archive info dialog from image plugin to the image gallery plugin.
Requires latest dev version of writer dev, or add the following to the `se.infomaker.imagegallery` config:

```json
"imageInfoEnabled": true
```