### PR TITLE
wplug 227 iframely alternate rendering

### DIFF
--- a/plugins/se.infomaker.iframely/IframelyComponent.js
+++ b/plugins/se.infomaker.iframely/IframelyComponent.js
@@ -5,6 +5,11 @@ import Package from './IframelyPackage'
 
 class IframelyComponent extends Component {
 
+    constructor(...args) {
+        super(...args)
+        api.document.triggerFetchResourceNode(this.props.node, {history: false})
+    }
+
     didMount() {
         // Rerender component when the embedCode has loaded
         this.context.editorSession.onRender('document', this._onDocumentChange, this)

--- a/plugins/se.infomaker.iframely/IframelyConverter.js
+++ b/plugins/se.infomaker.iframely/IframelyConverter.js
@@ -8,7 +8,9 @@ const IframelyConverter = {
 
     // Convert newsml to node
     import: function(el, node) {
-        if (el.attr('uuid')) { node.uuid = el.attr('uuid') }
+        if (el.attr('uuid')) {
+            node.uuid = el.attr('uuid')
+        }
 
         const titleElem = el.find('title')
         const embedCodeElem = el.find('embedCode')
@@ -32,7 +34,9 @@ const IframelyConverter = {
         const titleElem = $$('title')
         const embedCodeElem = $$('embedCode')
 
-        if (node.uuid) { el.attr('uuid', node.uuid) }
+        if (node.uuid) {
+            el.attr('uuid', node.uuid)
+        }
         el.attr('type', node.dataType)
         el.attr('url', node.url)
 

--- a/plugins/se.infomaker.iframely/IframelyConverter.js
+++ b/plugins/se.infomaker.iframely/IframelyConverter.js
@@ -48,6 +48,55 @@ const IframelyConverter = {
 
         dataElem.append([titleElem, embedCodeElem])
         el.append(dataElem)
+
+        const api = converter.context.api
+        let configLabel = api.getConfigValue('se.infomaker.iframely', 'alternateLinkTitle', '{text}')
+
+        const oembed = node.oembed
+        const alternateLink = converter.$$('link')
+        const linksEl = $$('links')
+
+        const title = configLabel.replace('{author_name}', oembed.author_name)
+            .replace('{author_url}', oembed.author_url)
+            .replace('{provider_name}', oembed.provider_name)
+            .replace('{provider_url}', oembed.provider_url)
+            .replace('{text}', oembed.title ? oembed.title : '')
+
+        alternateLink.attr({
+            rel: 'alternate',
+            type: 'text/html',
+            url: node.url,
+            title: title
+        })
+
+        linksEl.append(alternateLink)
+
+        if(oembed.thumbnail_url) {
+            const alternateImageLink = $$('link')
+            const imageData = $$('data')
+
+            // Create the image/alternate
+            alternateImageLink.attr({
+                rel: 'alternate',
+                type: 'image/jpg',
+                url: oembed.thumbnail_url
+            })
+
+            // Check if we have width and height of thumbail
+            if(oembed.thumbnail_width) {
+                imageData.append($$('width').append(oembed.thumbnail_width))
+            }
+            if(oembed.thumbnail_height) {
+                imageData.append($$('height').append(oembed.thumbnail_height))
+            }
+            if(imageData.childNodes.length > 0) {
+                alternateImageLink.append(imageData)
+            }
+
+            linksEl.append(alternateImageLink)
+        }
+
+        el.append(linksEl)
     }
 }
 

--- a/plugins/se.infomaker.iframely/IframelyConverter.js
+++ b/plugins/se.infomaker.iframely/IframelyConverter.js
@@ -56,10 +56,9 @@ const IframelyConverter = {
         const alternateLink = converter.$$('link')
         const linksEl = $$('links')
 
-        const title = configLabel.replace('{author_name}', oembed.author_name)
+        const title = configLabel.replace('{author_name}', oembed.author)
             .replace('{author_url}', oembed.author_url)
             .replace('{provider_name}', oembed.provider_name)
-            .replace('{provider_url}', oembed.provider_url)
             .replace('{text}', oembed.title ? oembed.title : '')
 
         alternateLink.attr({

--- a/plugins/se.infomaker.iframely/IframelyMacro.js
+++ b/plugins/se.infomaker.iframely/IframelyMacro.js
@@ -1,26 +1,34 @@
-import { api } from 'writer'
+import {api} from 'writer'
 import urlShouldBeMatched from './urlShouldBeMatched'
 import insertIframelyEmbed from './insertIframelyEmbed'
 
 const IframelyMacro = {
-    execute: function (params, context) {
+    execute: function(params, context) {
         const es = context.editorSession
-        const { selection, text, action } = params
+        const {selection, text, action} = params
 
         // Only run macro on paste and break
-        if (action !== 'paste' && action !== 'break') { return false }
+        if (action !== 'paste' && action !== 'break') {
+            return false
+        }
 
         // Extract url from text
         const url = /^(https?:\/\/([^\s]+))$/.exec(text)
 
         // Break if the pasted text is not a URL
-        if(!url) { return false }
+        if (!url) {
+            return false
+        }
 
         // Break if the URL should not be matched
-        if (!urlShouldBeMatched(url)) { return false }
+        if (!urlShouldBeMatched(url)) {
+            return false
+        }
 
         const nodeId = selection.getNodeId()
-        if (!nodeId) { return false }
+        if (!nodeId) {
+            return false
+        }
 
         const doc = es.getDocument()
 

--- a/plugins/se.infomaker.iframely/IframelyNode.js
+++ b/plugins/se.infomaker.iframely/IframelyNode.js
@@ -1,7 +1,6 @@
 import {api} from 'writer'
 import {BlockNode} from 'substance'
 import fetchOembed from './fetchOembed'
-// import fetchWriterIframe from './fetchWriterIframe'
 
 class IframelyNode extends BlockNode {
 
@@ -12,13 +11,6 @@ class IframelyNode extends BlockNode {
 
         this.fetching = true
 
-        /**
-         * Might need to be deprecated, needs to fetch all info
-         * to be able to fill alternative-links
-         * if (this.embedCode) {
-         *   return this.loadFromNode(callback)
-         * }
-         */
         return fetchOembed(this.url)
             .then(res => {
                 if (!res.html) {
@@ -46,20 +38,6 @@ class IframelyNode extends BlockNode {
                 }
             })
     }
-
-    /**
-     * Load everything from the node and add the writer iframe
-     * TODO: might be deprecated, unless we save most of the oembed data on the node
-     * @param  {function} callback
-     */
-    // loadFromNode(callback) {
-    //     fetchWriterIframe(this.url).then(writerIframe => {
-    //         this.fetching = false
-    //         callback(null, {
-    //             iframe: writerIframe
-    //         })
-    //     })
-    // }
 
     /**
      * Restore the pasted link

--- a/plugins/se.infomaker.iframely/IframelyNode.js
+++ b/plugins/se.infomaker.iframely/IframelyNode.js
@@ -1,41 +1,46 @@
-import { api } from 'writer'
-import { BlockNode } from 'substance'
+import {api} from 'writer'
+import {BlockNode} from 'substance'
 import fetchOembed from './fetchOembed'
 import fetchWriterIframe from './fetchWriterIframe'
 
 class IframelyNode extends BlockNode {
 
     fetchPayload(context, callback) {
-        if (this.fetching) return callback(null, {})
+        if (this.fetching) {
+            return callback(null, {})
+        }
 
         this.fetching = true
 
-        if (this.embedCode) return this.loadFromNode(callback)
+        if (this.embedCode) {
+            return this.loadFromNode(callback)
+        }
 
         fetchOembed(this.url)
-        .then(res => {
-            if (!res.html) {
-                throw new Error('No embedCode found for link')
-            }
+            .then(res => {
+                if (!res.html) {
+                    throw new Error('No embedCode found for link')
+                }
 
-            this.fetching = false
-            callback(null, {
-                url: res.url,
-                title: res.title,
-                provider: res.provider_name,
-                embedCode: res.html,
-                iframe: res.writerIframe
+                this.fetching = false
+                return callback(null, {
+                    url: res.url,
+                    title: res.title,
+                    provider: res.provider_name,
+                    embedCode: res.html,
+                    iframe: res.writerIframe
+                })
             })
-        }).catch(err => {
-            this.fetching = false
-            callback(err)
-            this.remove()
+            .catch(err => {
+                this.fetching = false
+                callback(err)
+                this.remove()
 
-            // Restore the link if settings allow it
-            if (api.getConfigValue('se.infomaker.iframely', 'restoreAfterFailure', true)) {
-                this.restoreLink()
-            }
-        })
+                // Restore the link if settings allow it
+                if (api.getConfigValue('se.infomaker.iframely', 'restoreAfterFailure', true)) {
+                    this.restoreLink()
+                }
+            })
     }
 
     /**
@@ -75,12 +80,12 @@ class IframelyNode extends BlockNode {
 IframelyNode.isResource = true
 IframelyNode.type = 'iframely'
 IframelyNode.define({
-    embedCode: { type: 'string', optional: true },
-    iframe: { type: 'string', optional: true },
-    url: {type: 'string', optional: true },
-    dataType: { type: 'string' },
-    title: { type: 'string', optional: true },
-    errorMessage: { type: 'string', optional: true }
+    embedCode: {type: 'string', optional: true},
+    iframe: {type: 'string', optional: true},
+    url: {type: 'string', optional: true},
+    dataType: {type: 'string'},
+    title: {type: 'string', optional: true},
+    errorMessage: {type: 'string', optional: true}
 })
 
 export default IframelyNode

--- a/plugins/se.infomaker.iframely/IframelyNode.js
+++ b/plugins/se.infomaker.iframely/IframelyNode.js
@@ -1,7 +1,7 @@
 import {api} from 'writer'
 import {BlockNode} from 'substance'
 import fetchOembed from './fetchOembed'
-import fetchWriterIframe from './fetchWriterIframe'
+// import fetchWriterIframe from './fetchWriterIframe'
 
 class IframelyNode extends BlockNode {
 
@@ -12,11 +12,14 @@ class IframelyNode extends BlockNode {
 
         this.fetching = true
 
-        if (this.embedCode) {
-            return this.loadFromNode(callback)
-        }
-
-        fetchOembed(this.url)
+        /**
+         * Might need to be deprecated, needs to fetch all info
+         * to be able to fill alternative-links
+         * if (this.embedCode) {
+         *   return this.loadFromNode(callback)
+         * }
+         */
+        return fetchOembed(this.url)
             .then(res => {
                 if (!res.html) {
                     throw new Error('No embedCode found for link')
@@ -28,7 +31,8 @@ class IframelyNode extends BlockNode {
                     title: res.title,
                     provider: res.provider_name,
                     embedCode: res.html,
-                    iframe: res.writerIframe
+                    iframe: res.writerIframe,
+                    oembed: res
                 })
             })
             .catch(err => {
@@ -45,16 +49,17 @@ class IframelyNode extends BlockNode {
 
     /**
      * Load everything from the node and add the writer iframe
+     * TODO: might be deprecated, unless we save most of the oembed data on the node
      * @param  {function} callback
      */
-    loadFromNode(callback) {
-        fetchWriterIframe(this.url).then(writerIframe => {
-            this.fetching = false
-            callback(null, {
-                iframe: writerIframe
-            })
-        })
-    }
+    // loadFromNode(callback) {
+    //     fetchWriterIframe(this.url).then(writerIframe => {
+    //         this.fetching = false
+    //         callback(null, {
+    //             iframe: writerIframe
+    //         })
+    //     })
+    // }
 
     /**
      * Restore the pasted link
@@ -85,7 +90,8 @@ IframelyNode.define({
     url: {type: 'string', optional: true},
     dataType: {type: 'string'},
     title: {type: 'string', optional: true},
-    errorMessage: {type: 'string', optional: true}
+    errorMessage: {type: 'string', optional: true},
+    oembed: { type: 'object', optional: true }
 })
 
 export default IframelyNode

--- a/plugins/se.infomaker.iframely/README.md
+++ b/plugins/se.infomaker.iframely/README.md
@@ -17,7 +17,8 @@ Documentation of the Iframely plugin.
         "restoreAfterFailure": true,
         "omitScript": false,
         "urlWhitelist": [],
-        "urlBlacklist": []
+        "urlBlacklist": [],
+        "alternateLinkTitle": "{author_name} posted {text}"
     }
 }
 ```
@@ -56,6 +57,28 @@ Set to true to disable adding the included iframely embed.js script to all embed
 // Don't match URLs that end in '/foo' or '/bar'
 "urlBlacklist": [/\/foo$/, /\/bar$/]
 ```
+
+### `alternateLinkTitle` - Link Title Template String
+*Optional* ASets a template which renders the `title`-attribute in the `alternate`-link. The template is able to fetch properties
+from the fetched oEmbed values from the Iframely API. Default value is `"{text}"`.
+
+#### Available Template Tags
+| Tag | Description |
+| --- | ----------- |
+| `{author_name}` | Name of author/creator |
+| `{author_url}` | Url to author of content |
+| `{provider_name}` | Provider of resource, e.g YouTube, Instagram |
+| `{text}` | Title of the content |
+
+#### Example
+```js
+    "alternateLinkTitle": "{author_name} posted {text} on {provider}"
+```
+Would render
+```
+    Test Testsson posted My Cool Article on Instagram
+```
+
 
 ### 1.2 - Iframely settings
 Some settings can only be changed on the Iframely [settings page](https://iframely.com/settings/api)

--- a/plugins/se.infomaker.iframely/urlShouldBeMatched.js
+++ b/plugins/se.infomaker.iframely/urlShouldBeMatched.js
@@ -1,4 +1,4 @@
-import { api } from 'writer'
+import {api} from 'writer'
 
 /**
  * @private
@@ -8,7 +8,9 @@ import { api } from 'writer'
  */
 const _testUrlAgainstList = (url, list) => {
     for (let i = 0; i < list.length; i++) {
-        if (list[i].test(url)) { return true }
+        if (list[i].test(url)) {
+            return true
+        }
     }
     return false
 }
@@ -20,7 +22,9 @@ const _testUrlAgainstList = (url, list) => {
  */
 const urlInWhitelist = (url) => {
     const whitelist = api.getConfigValue('se.infomaker.iframely', 'urlWhitelist', [])
-    if (whitelist.length === 0) { return true }
+    if (whitelist.length === 0) {
+        return true
+    }
     return _testUrlAgainstList(url, whitelist)
 }
 
@@ -31,7 +35,9 @@ const urlInWhitelist = (url) => {
  */
 const urlInBlacklist = (url) => {
     const blacklist = api.getConfigValue('se.infomaker.iframely', 'urlBlacklist', [])
-    if (blacklist.length === 0) { return false }
+    if (blacklist.length === 0) {
+        return false
+    }
     return _testUrlAgainstList(url, blacklist)
 }
 


### PR DESCRIPTION
Should now render alternate links used when iframe-rendering is not supported.
Uses very similar functions as youtube-embed plugin, and should maybe be reworked later, so we maybe save more oembed properties directly on the node, not just embed code.