### PR TITLE
Feature/wplug 234 improved alternate elements

### DIFF
--- a/plugins/se.infomaker.iframely/IframelyConverter.js
+++ b/plugins/se.infomaker.iframely/IframelyConverter.js
@@ -148,8 +148,7 @@ const IframelyConverter = {
     _getContextForProvider(api, oembedExporter) {
         const defaultContexts = {
             'Video': ['youtube', 'vimeo'],
-            'Social': ['instagram', 'twitter', 'facebook'],
-            'Audio': ['spotify', 'itunes', 'soundcloud']
+            'Social': ['instagram', 'twitter', 'facebook']
         }
         const configuredContexts = api.getConfigValue('se.infomaker.iframely', 'contexts', {})
 

--- a/plugins/se.infomaker.iframely/IframelyConverter.js
+++ b/plugins/se.infomaker.iframely/IframelyConverter.js
@@ -107,7 +107,7 @@ const IframelyConverter = {
         const {description, provider_name: providerName} = oembed
 
         const oembedExporter = new OEmbedExporter(oembed)
-        const context = this._getContextForProvider(providerName, api, oembedExporter)
+        const context = this._getContextForProvider(api, oembedExporter)
 
         const alternateLink = $$('link')
         const title = oembedExporter.getTitle(configLabel)
@@ -140,20 +140,12 @@ const IframelyConverter = {
 
     /**
      *
-     *
-     * @param providerName
      * @param api
      * @param {OEmbedExporter} oembedExporter
      * @returns string|boolean
      * @private
      */
-    _getContextForProvider(providerName, api, oembedExporter) {
-        if (!providerName) {
-            return false
-        }
-
-        providerName = providerName.toLowerCase()
-
+    _getContextForProvider(api, oembedExporter) {
         const defaultContexts = {
             'Video': ['youtube', 'vimeo'],
             'Social': ['instagram', 'twitter', 'facebook'],

--- a/plugins/se.infomaker.iframely/README.md
+++ b/plugins/se.infomaker.iframely/README.md
@@ -18,7 +18,10 @@ Documentation of the Iframely plugin.
         "omitScript": false,
         "urlWhitelist": [],
         "urlBlacklist": [],
-        "alternateLinkTitle": "{author_name} posted {text}"
+        "alternateLinkTitle": "{author_name} posted {text}",
+        "contexts": {
+            "Overridden": ["youtube", "twitter"]
+        }
     }
 }
 ```
@@ -59,8 +62,39 @@ Set to true to disable adding the included iframely embed.js script to all embed
 ```
 
 ### `alternateLinkTitle` - Link Title Template String
-*Optional* ASets a template which renders the `title`-attribute in the `alternate`-link. The template is able to fetch properties
+*Optional* Sets a template which renders the `title`-attribute in the `alternate`-link. The template is able to fetch properties
 from the fetched oEmbed values from the Iframely API. Default value is `"{text}"`.
+
+### `contexts` - Object containing contexts and lowercased provider names
+*Optional* Only relevant for alternate rendering methods.
+It's possible to override an embedded content's context, or creating new contexts
+for content not built into the plugin.
+
+#### Default Provider Contexts
+The iFramely plugin supports some popular embeddable providers and maps these
+to default contexts. If a provider is not supported, and not specified in
+the plugin's `contexts`-config, the `<context>`-element in the newsML is omitted.
+
+| Context | Providers |
+| ------- | --------- |
+| Video   | youtube, vimeo |
+| Social  | instagram, twitter, facebook |
+
+#### Context Override Example
+To add a provider to a different or new context, or add a new provider to a context, use the
+following format:
+```json
+"contexts": {
+    "Different Youtube Context": ["youtube"], // Provider should be lowercased
+    "New Context": ["linkedin"] // Adding a new context and new provider
+}
+```
+
+The plugin will check the configured contexts first, then default contexts.
+
+To find the provider-name of an embeddable source, test the url at [iFramely's test tool](https://iframely.com/embed).
+
+
 
 #### Available Template Tags
 | Tag | Description |
@@ -98,6 +132,21 @@ The option `Respond with error 417 when API call results in no embed codes` shou
             <![CDATA[<iframe src="..."></iframe>]]>
         </embedCode>
     </data>
+    <links>
+        <link rel="alternate" type="text/html" title="Instagram post by Cats of Instagram  from Instagram" url="https://www.instagram.com/p/BeglN_bHruW/?hl=en&amp;taken-by=cats_of_instagram">
+            <data>
+                <context>Social</context>
+                <description>From @Morris_the_persian_cat: "Hey ladies! Wanna know what my sweater is made of? Boyfriend material." #catsofinstagram</description>
+                <provider>Instagram</provider>
+            </data>
+        </link>
+        <link rel="alternate" type="image/jpg" url="https://scontent-iad3-1.cdninstagram.com/vp/2543b8ff10bea7a919032afe8fb7a7ec/5B02A2F2/t51.2885-15/e35/26429239_1589573814423494_7174194954695081984_n.jpg">
+            <data>
+                <width>1080</width>
+                <height>1080</height>
+            </data>
+        </link>
+    </links>
 </object>
 ```
 ### 2.1 - Object
@@ -123,3 +172,5 @@ The title of the embed provided in the oembed response.
 </embedCode>
 ```
 The embed data returned by the Iframely API is stored as `<embedCode>`.
+
+### 2.3 - Object > links

--- a/plugins/se.infomaker.socialembed/SocialembedConverter.js
+++ b/plugins/se.infomaker.socialembed/SocialembedConverter.js
@@ -1,3 +1,5 @@
+import {OEmbedExporter} from 'writer'
+
 const socialEmbedConverter = {
     type: 'socialembed',
     tagName: 'object',
@@ -16,7 +18,7 @@ const socialEmbedConverter = {
     },
 
     export: function (node, el, converter) {
-        const $$ = converter.$$;
+        const $$ = converter.$$
 
         el.attr({
             id: node.id,
@@ -25,8 +27,8 @@ const socialEmbedConverter = {
 
         el.removeAttr('data-id');
 
-        const links = $$('links'),
-            link = $$('link')
+        const links = $$('links')
+        const link = $$('link')
 
         link.attr({
             rel: 'self',
@@ -53,7 +55,7 @@ const socialEmbedConverter = {
     },
 
 
-    _createTitleForAlternateLink: (linkType, data, converter) => {
+    _createTitleForAlternateLink: (linkType, oembed, converter) => {
 
         const configKeysForLinkType = new Map()
         configKeysForLinkType.set('x-im/instagram', 'alternateInstagramTitle')
@@ -66,12 +68,9 @@ const socialEmbedConverter = {
         }
         let configLabel = converter.context.api.getConfigValue('se.infomaker.socialembed', configKey, '{author_name} posted on {provider_name}')
 
-        configLabel = configLabel.replace('{author_name}', data.author_name)
-        configLabel = configLabel.replace('{author_url}', data.author_url)
-        configLabel = configLabel.replace('{provider_name}', data.provider_name)
-        configLabel = configLabel.replace('{provider_url}', data.provider_url)
-        configLabel = configLabel.replace('{text}', data.title ? data.title : '')
-        return configLabel
+        const oembedExporter = new OEmbedExporter(oembed)
+
+        return oembedExporter.getTitle(configLabel)
     },
 
     /**
@@ -82,16 +81,24 @@ const socialEmbedConverter = {
      * @private
      */
     _createDefaultAlternateLink: (node, converter) => {
-        const alternateLink = converter.$$('link')
+        const {$$} = converter
+        const alternateLink = $$('link')
         alternateLink.attr({
             rel: 'alternate',
             type: 'text/html',
             url: node.url,
-            title:  socialEmbedConverter._createTitleForAlternateLink(node.linkType, node.oembed, converter)
+            title: socialEmbedConverter._createTitleForAlternateLink(node.linkType, node.oembed, converter)
         })
+
+        alternateLink.append(
+            $$('data').append(
+                $$('context').append('Social'),
+                $$('provider').append(node.oembed.provider_name)
+            )
+        )
+
         return alternateLink
     },
-
 
     /**
      * For Instagram we need to create two links, one for the url itself and another for the thumbnail
@@ -101,13 +108,10 @@ const socialEmbedConverter = {
      * @private
      */
     _createAlternateLinkForInstagram: (node, converter) => {
-
-
-
         const $$ = converter.$$
-        const alternateLink = $$('link'),
-            alternateImageLink = $$('link'),
-            imageData = $$('data')
+        const alternateLink = $$('link')
+        const alternateImageLink = $$('link')
+        const imageData = $$('data')
 
         // Create the text/html link
         alternateLink.attr({
@@ -116,6 +120,13 @@ const socialEmbedConverter = {
             url: node.url,
             title: socialEmbedConverter._createTitleForAlternateLink(node.linkType, node.oembed, converter)
         })
+
+        alternateLink.append(
+            $$('data').append(
+                $$('context').append('Social'),
+                $$('provider').append(node.oembed.provider_name)
+            )
+        )
 
         // Create the image/alternate
         alternateImageLink.attr({
@@ -139,7 +150,7 @@ const socialEmbedConverter = {
     },
 
     /**
-     * 
+     *
      * @param converter
      * @returns {*|string|null}
      * @private

--- a/plugins/se.infomaker.youtubeembed/YoutubeEmbedConverter.js
+++ b/plugins/se.infomaker.youtubeembed/YoutubeEmbedConverter.js
@@ -64,7 +64,8 @@ export default {
 
         alternateLink.append(
             $$('data').append(
-                $$('context').append('Video')
+                $$('context').append('Video'),
+                $$('provider').append(node.oembed.provider_name)
             )
         )
 

--- a/plugins/se.infomaker.youtubeembed/YoutubeEmbedConverter.js
+++ b/plugins/se.infomaker.youtubeembed/YoutubeEmbedConverter.js
@@ -1,5 +1,4 @@
-
-import {moment} from 'writer'
+import {moment, OEmbedExporter} from 'writer'
 
 export default {
     type: 'youtubeembed',
@@ -49,22 +48,25 @@ export default {
         let configLabel = api.getConfigValue('se.infomaker.youtubeembed', 'alternateLinkTitle', 'Click link to view content')
 
         const oembed = node.oembed
-        configLabel = configLabel.replace('{author_name}', oembed.author_name)
-        configLabel = configLabel.replace('{author_url}', oembed.author_url)
-        configLabel = configLabel.replace('{provider_name}', oembed.provider_name)
-        configLabel = configLabel.replace('{provider_url}', oembed.provider_url)
-        configLabel = configLabel.replace('{text}', oembed.title ? oembed.title : '')
+        const oembedExporter = new OEmbedExporter(oembed)
 
-        const alternateLink = converter.$$('link'),
-            alternateImageLink = $$('link'),
-            imageData = $$('data')
+        const title = oembedExporter.getTitle(configLabel)
+        const alternateLink = $$('link')
+        const alternateImageLink = $$('link')
+        const imageData = $$('data')
 
         alternateLink.attr({
             rel: 'alternate',
             type: 'text/html',
             url: node.url,
-            title: configLabel
+            title
         })
+
+        alternateLink.append(
+            $$('data').append(
+                $$('context').append('Video')
+            )
+        )
 
         // Create the image/alternate
         alternateImageLink.attr({


### PR DESCRIPTION
Requires Writer https://github.com/Infomaker/NPWriter/tree/feature/WPLUG-234_improved_alternate_elements to test.

Extends embeddable plugins' (iframely, youtube, socialembed) NewsML output to contain provider, context and description (only for iframely).

Also adds ability to create contexts for providers not supported directly by iframely plugin, via config. See readme.

Example extended output when pasting instagram-link:

```xml
<links>
    <link rel="alternate" type="text/html" title="Instagram post by Cats of Instagram  from Instagram"
          url="https://www.instagram.com/p/BeglN_bHruW/?hl=en&amp;taken-by=cats_of_instagram">
        <data>
            <context>Social</context>
            <description>From @Morris_the_persian_cat: "Hey ladies! Wanna know what my sweater is made of? Boyfriend material." #catsofinstagram</description>
            <provider>Instagram</provider>
        </data>
    </link>
    <link rel="alternate" type="image/jpg"
          url="https://scontent-iad3-1.cdninstagram.com/vp/2543b8ff10bea7a919032afe8fb7a7ec/5B02A2F2/t51.2885-15/e35/26429239_1589573814423494_7174194954695081984_n.jpg">
        <data>
            <width>1080</width>
            <height>1080</height>
        </data>
    </link>
</links>
```