### PR TITLE
images can now handle external flags

### DIFF
--- a/plugins/se.infomaker.ximimage/README.md
+++ b/plugins/se.infomaker.ximimage/README.md
@@ -25,6 +25,7 @@ The image plugin configuration must have several things defined to work correctl
         "hideDisableCropsCheckbox": true, // Default false
         "crops": { ... },
         "fields": [ ... ],
+        "externalFlags": [ ... ],
         "cropInstructions": { ... },
         "propertyMap": { ... }
     }
@@ -168,6 +169,24 @@ by default when a new image is added to the article.
             }
         ],
         "defaultValue": "left"
+    }
+]
+```
+
+#### External flags
+*Optional* The Image plugin can handle external flags not included by default. You can now toggle the external flags defined
+in the config. Flags not listed in the config will be respected and left as is. Each flag represents an object with the `name`
+as the actual flag and the `label` as a readable representation.  
+
+```json
+"externalFlags": [
+    {
+        "name": "bwFilter",
+        "label": "Black and White" 
+    },
+    {
+        "name": "blurFilter",
+        "label": "Blur faces"
     }
 ]
 ```

--- a/plugins/se.infomaker.ximimage/Ximimage.js
+++ b/plugins/se.infomaker.ximimage/Ximimage.js
@@ -39,6 +39,12 @@ class Ximimage extends withTraits(BlockNode, imageNodeTrait, imageCropTrait, aut
             tx.set([this.id, 'alignment'], alignment)
         })
     }
+
+    setExternalFlags(flags) {
+        api.editorSession.transaction((tx) => {
+            tx.set([this.id, 'externalFlags'], flags)
+        })
+    }
 }
 
 function isUnset(field) {
@@ -74,7 +80,8 @@ Ximimage.define({
     caption: {type: 'string', default: ''},
     alttext: {type: 'string', optional: true},
     credit: {type: 'string', optional: true},
-    alignment: {type: 'string', optional: true}
+    alignment: {type: 'string', optional: true},
+    externalFlags: {type: 'array', default: [], optional: true}
 })
 
 export default Ximimage

--- a/plugins/se.infomaker.ximimage/XimimageConverter.js
+++ b/plugins/se.infomaker.ximimage/XimimageConverter.js
@@ -61,6 +61,7 @@ export default {
         node.credit = ''
         node.alignment = ''
         node.disableAutomaticCrop = false
+        node.externalFlags = []
 
         if (dataEl) {
             dataEl.children.forEach(function (child) {
@@ -98,6 +99,8 @@ export default {
                 flagsEl.children.forEach(childEl => {
                     if (childEl.text() === 'disableAutomaticCrop') {
                         node.disableAutomaticCrop = true
+                    } else {
+                        node.externalFlags.push(childEl.text());
                     }
                 })
             }
@@ -188,12 +191,23 @@ export default {
             $$('height').append(String(node.height)),
         ])
 
+        let flags = $$('flags');
+        let appendFlags = false;
+
         if (node.disableAutomaticCrop) {
-            data.append(
-                $$('flags').append(
-                    $$('flag').append('disableAutomaticCrop')
-                )
+            appendFlags = true;
+            flags.append(
+                $$('flag').append('disableAutomaticCrop')
             )
+        }
+
+        if (node.externalFlags.length) {
+            appendFlags = true;
+            node.externalFlags.forEach(extFlag => flags.append($$('flag').append(extFlag)))
+        }
+
+        if (appendFlags) {
+            data.append(flags);
         }
 
         let fields = api.getConfigValue('se.infomaker.ximimage', 'fields') || []

--- a/plugins/se.infomaker.ximimage/components/Ximimage.js
+++ b/plugins/se.infomaker.ximimage/components/Ximimage.js
@@ -1,5 +1,5 @@
 import {Component} from "substance"
-import {UIFieldEditor, UIByline} from 'writer'
+import {UIFieldEditor, UIByline, UIToggle} from 'writer'
 import ImageDisplay from "./ImageDisplay"
 import ImageCropsPreview from "./ImageCropsPreview"
 
@@ -59,6 +59,7 @@ class XimimageComponent extends Component {
         let cropsEnabled = api.getConfigValue('se.infomaker.ximimage', 'softcrop')
         let crops = api.getConfigValue('se.infomaker.ximimage', 'crops')
         let cropInstructions = api.getConfigValue('se.infomaker.ximimage', 'cropInstructions')
+        let externalFlags = api.getConfigValue('se.infomaker.ximimage', 'externalFlags') || []
 
         // TODO: extract from full config when we can get that
         const imageOptions = ['byline', 'imageinfo', 'softcrop', 'crops', 'bylinesearch', 'hideDisableCropsCheckbox'].reduce((optionsObject, field) => {
@@ -102,6 +103,16 @@ class XimimageComponent extends Component {
             }
         })
 
+        if (externalFlags.length) {
+            let flagWrapper = $$('div')
+                .attr('contenteditable', false)
+                .addClass('x-im-image-dynamic x-im-image-flags')
+            externalFlags.forEach(obj => {
+                flagWrapper.append(this.renderFlags($$, obj))
+            })
+            metaWrapper.append(flagWrapper)
+        }
+
         el.append(metaWrapper)
 
         return el
@@ -137,6 +148,24 @@ class XimimageComponent extends Component {
             .ref(obj.name)
             .attr('title', obj.label)
             .addClass('x-im-image-dynamic')
+    }
+
+    renderFlags($$, flag) {
+        let isChecked = this.props.node.externalFlags.includes(flag.name) ? true : false
+        return $$(UIToggle, {
+            id: this.props.node.id + '_flag_' + flag.name,
+            label: this.getLabel(flag.label),
+            checked: isChecked,
+            enabled: !this.props.disabled,
+            onToggle: (checked) => {
+                if (checked) {
+                    this.props.node.externalFlags.push(flag.name)
+                } else {
+                    this.props.node.externalFlags = this.props.node.externalFlags.filter(extFlag => extFlag !== flag.name)
+                }
+                this.props.node.setExternalFlags(this.props.node.externalFlags)
+            }
+        })
     }
 
     _getFieldIcon(name) {

--- a/plugins/se.infomaker.ximimage/scss/ximimage.scss
+++ b/plugins/se.infomaker.ximimage/scss/ximimage.scss
@@ -14,6 +14,24 @@ div.x-im-image-dynamic {
         padding-bottom: 12px;
     }
 
+    &.x-im-image-flags {
+        pointer-events: none;
+        margin-top: 10px;
+        &::before {
+            font-family: FontAwesome;
+            opacity: 0.5;
+            float: left;
+            content: "\F024";
+            width: 31px;
+            left: 50px;
+            top: 2px;
+        }
+        .np-toggle {
+            display: inline-block;
+            margin-right: 10px;
+        }
+    }
+
     &.x-im-image-alignment {
         margin-top: 10px;
         padding-left: 28px;
@@ -50,11 +68,13 @@ div.x-im-image-dynamic {
     }
 }
 
-
 .sc-isolated-node.sm-selected {
     .sc-ximimage {
         div.x-im-image-dynamic:last-child {
             border-bottom: none;
+        }
+        .x-im-image-flags {
+            pointer-events: all;
         }
     }
 }


### PR DESCRIPTION
Made an update to the ximimage-plugin allowing users to define external flags and toggle these in the image-area.

Further the image-plugin also respects other flags not in the config, before every flag set (excluding the disableCrop) was wiped when exporting.

Feel free to edit or otherwise scrap it all - but we do need some way to at least contain flags - and ideally even handle them in a nice way.

![image](https://user-images.githubusercontent.com/9556328/60424329-56aac800-9bf0-11e9-9b70-7998d52706c1.png)
